### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ export default async function Dog({ params }) {
 
 ### `buildCommand: string`
 
-Specify a custom build command. Defaults to `next build`.
+Specify a custom build command. Defaults to `npm run build`.
 
 > Note: the extension will skip building if the `prebuilt` option is set to `true`
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Most Next.js features are supported as we rely on the Next.js Server provided by
 
 ## Usage
 
-> [!NOTE] 
+> [!NOTE]
 > This guide assumes you're already familiar with [HarperDb Components](https://docs.harperdb.io/docs/developers/components). Please review the documentation, or check out the HarperDB [Next.js Example](https://github.com/HarperDB/nextjs-example) for more information.
 
 1. Install:
@@ -59,7 +59,6 @@ export async function listDogs() {
 export async function getDog(id) {
 	return tables.Dog.get(id);
 }
-
 ```
 
 ```js
@@ -83,7 +82,6 @@ export default async function Dog({ params }) {
 		</section>
 	);
 }
-
 ```
 
 ## Options
@@ -117,7 +115,6 @@ Specify a port for the Next.js server. Defaults to `3000`.
 ### `prebuilt: boolean`
 
 When enabled, the extension will look for a `.next` directory in the root of the component and skip executing the `buildCommand`. Defaults to `false`.
-
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ export default async function Dog({ params }) {
 
 ### `buildCommand: string`
 
-Specify a custom build command. Defaults to `npm run build`.
+Specify a custom build command. Defaults to `next build`.
 
 > Note: the extension will skip building if the `prebuilt` option is set to `true`
 

--- a/extension.js
+++ b/extension.js
@@ -83,7 +83,7 @@ const nextJSAppCache = {};
 /**
  * This function verifies if the input is a Next.js app through a couple of
  * verification methods. It does not return nor throw anything. It will either
- * succeed (and return the path to the Next.js main file), or log an error to 
+ * succeed (and return the path to the Next.js main file), or log an error to
  * `logger.fatal` and exit the process with exit code 1.
  *
  * Additionally, it memoizes previous verifications.
@@ -185,7 +185,7 @@ async function executeCommand(commandInput, componentPath) {
 	cp.on('error', (error) => {
 		throw error;
 	});
-	([exitCode] = await events.once(cp, 'exit'));
+	[exitCode] = await events.once(cp, 'exit');
 
 	logger.debug(`Command: \`${commandInput}\` exited with ${exitCode}`);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "0.0.4",
 			"license": "MIT",
 			"dependencies": {
-				"semver": "^7.6.3",
 				"shell-quote": "^1.8.1"
 			},
 			"bin": {
@@ -44,18 +43,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
-			}
-		},
-		"node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/shell-quote": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
 		"format": "prettier --write ."
 	},
 	"dependencies": {
-		"semver": "^7.6.3",
 		"shell-quote": "^1.8.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
- removes Next.js version limitation
- invokes next.js through its specified main path (`package.json#main`)
- removes dependency on semver
- Includes project's `node_modules/.bin` in the child_process path so that `next build` works correctly
- adds command existance check via `which`