### PR TITLE
add a root .dockerignore to prevent node_modules from being copied

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules


### PR DESCRIPTION
Noticed node_modules was getting included in the COPY operations for fixtures which could cause build issues if there were symlinks within it. 

Unfortunately docker doesn't let me pass a dockerignore path to the build command, it just must be present in the build context directory (which is the root of the repo for all build ops). 

I'd like to eventually move to a colocated dockerfile setup (dockerfile will be located within the fixture itself) and that will clean this up some more. But that requires more work than this easy fix.