### PR TITLE
Add build timer

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -247,8 +247,8 @@ export function startOnMainThread(options = {}) {
 				const timerStart = performance.now();
 				await executeCommand(config.buildCommand, componentPath);
 				const timerStop = performance.now();
-				// const duration = timerStop - timerStart;
 				const durationInSeconds = (((timerStop - timerStart) % 60000) / 1000).toFixed(2);
+				
 				console.log(`The build took ${durationInSeconds} seconds`);
 
 				if (config.buildOnly) process.exit(0);

--- a/extension.js
+++ b/extension.js
@@ -4,6 +4,7 @@ import url from 'node:url';
 import child_process from 'node:child_process';
 import assert from 'node:assert';
 import { createRequire } from 'node:module';
+import { performance } from 'node:perf_hooks';
 
 import shellQuote from 'shell-quote';
 
@@ -243,7 +244,12 @@ export function startOnMainThread(options = {}) {
 			}
 
 			if (!config.prebuilt && !config.dev) {
+				const timerStart = performance.now();
 				await executeCommand(config.buildCommand, componentPath);
+				const timerStop = performance.now();
+				// const duration = timerStop - timerStart;
+				const durationInSeconds = (((timerStop - timerStart) % 60000) / 1000).toFixed(2);
+				console.log(`The build took ${durationInSeconds} seconds`);
 
 				if (config.buildOnly) process.exit(0);
 			}

--- a/extension.js
+++ b/extension.js
@@ -247,9 +247,13 @@ export function startOnMainThread(options = {}) {
 				const timerStart = performance.now();
 				await executeCommand(config.buildCommand, componentPath);
 				const timerStop = performance.now();
-				const durationInSeconds = (((timerStop - timerStart) % 60000) / 1000).toFixed(2);
-				
-				console.log(`The build took ${durationInSeconds} seconds`);
+				const duration = timerStop - timerStart;
+				logger.info(`The build took ${((duration % 60000) / 1000).toFixed(2)} seconds`);
+
+				// Send build time to HDB analtyics
+				let pathString = componentPath.toString().slice(0, -1);
+				const projectDirectoryName = pathString.split("/").pop();
+				server.recordAnalytics(duration, 'nextjs_build_time_in_milliseconds', projectDirectoryName);
 
 				if (config.buildOnly) process.exit(0);
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@harperdb/nextjs",
-	"version": "0.0.13",
+	"version": "0.0.14",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@harperdb/nextjs",
-			"version": "0.0.13",
+			"version": "0.0.14",
 			"license": "MIT",
 			"dependencies": {
 				"shell-quote": "^1.8.1"


### PR DESCRIPTION
This adds a timer for the Next.js build

Debating on the following:
To add harperdb component as dependency so I can access the [server global & send build output time to analytics](https://docs.harperdb.io/docs/technical-details/reference/globals#server)

