### PR TITLE
feat: support harper-pro distribution in integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,38 +16,54 @@ on:
           - '20'
           - '22'
           - '24'
+      distribution:
+        description: 'Harper distribution to test'
+        required: true
+        type: choice
+        default: 'all'
+        options:
+          - 'all'
+          - 'harper'
+          - 'harper-pro'
 
 jobs:
-  # TODO: Fix CI setup and re-enable
-  generate-node-version-matrix:
+  # TODO: Fix CI setup and re-enable (remove the `if: false` below)
+  generate-matrix:
     if: false
-    name: Generate Node Version Matrix
+    name: Generate Test Matrix
     runs-on: ubuntu-latest
     outputs:
-      node-versions: ${{ steps.set-node-versions.outputs.node-versions }}
+      node-versions: ${{ steps.set-matrix.outputs.node-versions }}
+      distributions: ${{ steps.set-matrix.outputs.distributions }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set Node versions
-        id: set-node-versions
+      - name: Set matrix values
+        id: set-matrix
         run: |
+          # Node versions
           if [ "${{ github.event.inputs.node-version }}" == "all" ] || [ -z "${{ github.event.inputs.node-version }}" ]; then
             echo "node-versions=[20, 22, 24]" >> $GITHUB_OUTPUT
           else
             echo "node-versions=[${{ github.event.inputs.node-version }}]" >> $GITHUB_OUTPUT
           fi
 
-  integration-tests:
-    name: Integration Tests (Node ${{ matrix.node-version }})
-    needs: generate-node-version-matrix
+          # Distributions
+          if [ "${{ github.event.inputs.distribution }}" == "all" ] || [ -z "${{ github.event.inputs.distribution }}" ]; then
+            echo 'distributions=["harper", "harper-pro"]' >> $GITHUB_OUTPUT
+          else
+            echo 'distributions=["${{ github.event.inputs.distribution }}"]' >> $GITHUB_OUTPUT
+          fi
+
+  # harper distribution tests — one runner per Node version
+  integration-tests-harper:
+    name: Integration Tests · harper · Node ${{ matrix.node-version }}
+    needs: generate-matrix
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        node-version: ${{ fromJson(needs.generate-node-version-matrix.outputs.node-versions) }}
+        node-version: ${{ fromJson(needs.generate-matrix.outputs.node-versions) }}
 
     steps:
       - name: Checkout code
@@ -71,7 +87,7 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Run integration tests
+      - name: Run integration tests (harper)
         run: npm run test:integration
         env:
           HARPER_INTEGRATION_TEST_LOG_DIR: /tmp/harper-test-logs
@@ -80,7 +96,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: harper-logs-node-${{ matrix.node-version }}
+          name: harper-logs-harper-node-${{ matrix.node-version }}
           path: /tmp/harper-test-logs/
           retention-days: 7
 
@@ -88,6 +104,60 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: playwright-traces-node-${{ matrix.node-version }}
+          name: playwright-traces-harper-node-${{ matrix.node-version }}
+          path: integrationTests/test-results/
+          retention-days: 7
+
+  # harper-pro distribution tests — one runner per Node version
+  integration-tests-harper-pro:
+    name: Integration Tests · harper-pro · Node ${{ matrix.node-version }}
+    needs: generate-matrix
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ${{ fromJson(needs.generate-matrix.outputs.node-versions) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build || true
+
+      - name: Install fixture dependencies
+        run: npm run install:fixtures
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run integration tests (harper-pro)
+        run: npm run test:integration:harper-pro
+        env:
+          HARPER_INTEGRATION_TEST_LOG_DIR: /tmp/harper-test-logs
+
+      - name: Upload Harper logs on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: harper-logs-harper-pro-node-${{ matrix.node-version }}
+          path: /tmp/harper-test-logs/
+          retention-days: 7
+
+      - name: Upload Playwright traces on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: playwright-traces-harper-pro-node-${{ matrix.node-version }}
           path: integrationTests/test-results/
           retention-days: 7

--- a/integrationTests/fixture.ts
+++ b/integrationTests/fixture.ts
@@ -10,7 +10,20 @@ import { test as base, expect } from '@playwright/test';
 
 const require = createRequire(import.meta.url);
 
+/**
+ * Resolve the Harper binary path based on the HARPER_DISTRIBUTION environment variable.
+ *
+ * - `harper` (default): uses the `harper` npm package (`dist/bin/harper.js` resolved via require)
+ * - `harper-pro`: uses the `@harperfast/harper-pro` package (`dist/bin/harper.js`)
+ *
+ * Set via `HARPER_DISTRIBUTION=harper-pro npm run test:integration` or use the
+ * dedicated `test:integration:harper-pro` npm script.
+ */
 function getHarperBinPath(): string {
+	const distribution = process.env.HARPER_DISTRIBUTION ?? 'harper';
+	if (distribution === 'harper-pro') {
+		return join(dirname(require.resolve('@harperfast/harper-pro/package.json')), 'dist', 'bin', 'harper.js');
+	}
 	return join(dirname(require.resolve('harper')), 'bin', 'harper.js');
 }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
 		"format:fix": "npm run format -- --write",
 		"build": "tsc -p tsconfig.build.json",
 		"install:fixtures": "node scripts/install-fixtures.js",
-		"test:integration": "playwright test --config integrationTests/playwright.config.ts"
+		"test:integration": "playwright test --config integrationTests/playwright.config.ts",
+		"test:integration:harper-pro": "HARPER_DISTRIBUTION=harper-pro npm run test:integration --"
 	},
 	"engines": {
 		"node": ">=20"


### PR DESCRIPTION
## Summary

- **`integrationTests/fixture.ts`**: `getHarperBinPath()` now reads `HARPER_DISTRIBUTION` env var — defaults to `harper`, switches to `@harperfast/harper-pro` (`dist/bin/harper.js`) when set to `harper-pro`
- **`package.json`**: new `test:integration:harper-pro` script sets `HARPER_DISTRIBUTION=harper-pro` so you can run `npm run test:integration:harper-pro` (or pass a specific file: `npm run test:integration:harper-pro -- integrationTests/next-16.pw.ts`)
- **`.github/workflows/integration-tests.yml`**: split the single `integration-tests` job into two named jobs (`integration-tests-harper`, `integration-tests-harper-pro`) each with their own `node-version` matrix — 3 Node versions × 2 distributions = 6 runners running in parallel, keeping each runner focused; added a `distribution` workflow_dispatch input for targeted manual runs; workflow remains disabled (`if: false` on `generate-matrix`) while the broader CI fix is in progress

## Local usage

```sh
# Run all tests with harper (default)
npm run test:integration

# Run a single test file with harper
npm run test:integration -- integrationTests/next-16.pw.ts

# Run all tests with harper-pro
npm run test:integration:harper-pro

# Run a single test file with harper-pro
npm run test:integration:harper-pro -- integrationTests/next-16.pw.ts

# Or set the env var directly
HARPER_DISTRIBUTION=harper-pro npx playwright test --config integrationTests/playwright.config.ts integrationTests/next-16.pw.ts
```

## Test plan

- [ ] `npm run test:integration` resolves to the `harper` bin (no env var set)
- [ ] `npm run test:integration:harper-pro` resolves to `@harperfast/harper-pro/dist/bin/harper.js`
- [ ] Single-file invocation works for both scripts
- [ ] Workflow matrix produces correct artifact name prefixes (`harper-logs-harper-*` vs `harper-logs-harper-pro-*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)