### PR TITLE
Use Harper readonly mode for Next.js builds

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,9 +25,9 @@ on:
         default: 'all'
         options:
           - 'all'
-          - '20'
           - '22'
           - '24'
+          - '26'
       harper_ref:
         description: 'HarperFast/harper ref to test against (branch, SHA, or tag). Empty = use pinned version.'
         required: false
@@ -58,7 +58,7 @@ jobs:
         run: |
           INPUT="${{ inputs.node-version }}"
           if [ "$INPUT" == "all" ] || [ -z "$INPUT" ]; then
-            echo "node-versions=[20, 22, 24]" >> $GITHUB_OUTPUT
+            echo "node-versions=[22, 24, 26]" >> $GITHUB_OUTPUT
           else
             echo "node-versions=[$INPUT]" >> $GITHUB_OUTPUT
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,9 @@ Review the `README.md` and `CONTRIBUTING.md` for all relevant repository informa
 ## Testing Tips
 
 - Use `npm link` in this directory and `npm link @harperfast/nextjs` in other project directories to test out changes locally
-- Run `npm run install:fixtures` before running tests for the first time, and again after changing any fixture's `package.json`.
+- Run `npm run install:fixtures` before running tests for the first time, and again after changing any fixture's `package.json` **or any plugin source under `src/`**. Fixtures install the plugin with `--install-links`, so each one holds a *copy* of `dist/`, not a symlink — `npm run build` alone does not reach them.
 - Run `npm run test:integration` to run all tests, or `npm run test:integration -- integrationTests/next-15.pw.ts` for a single file.
 - Test startup is slow by design — each test file starts a real Harper instance and waits for Next.js to build (up to 2 minutes). A slow start is not a failure.
 - The ISR cache tests in `integrationTests/next-16.pw.ts` are intentionally skipped; `CacheHandler.cts` is a work in progress.
+- `next-16-static-data` is run by two test files: `next-16-static-data.pw.ts` on the default VM module loader (where Harper's component `harper` allowlist omits `flushDatabases`, so the plugin's pre-build flush is a no-op and a read-only build child can't see unflushed writes) and `next-16-static-data-native.pw.ts` under `applications.moduleLoader: native`, where the flush does run. The pair is what pins that behavior down — keep both.
 - CI is currently disabled (`if: false` in `.github/workflows/integration-tests.yml`). Run tests locally.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ A [Harper Plugin](https://docs.harperdb.io/docs/reference/components/plugins) fo
 > [!NOTE]
 > This package currently supports **Next.js v14, v15, and v16** only.
 
+> [!IMPORTANT]
+> Requires **Harper v5** to run. **Static generation that reads Harper data at build time requires Harper v5.1 or newer** — it depends on the `HARPER_READONLY` build mode and `flushDatabases`, which do not exist in Harper v5.0.x. On Harper v5.0.x the build ignores read-only mode and fails when the build process cannot acquire the RocksDB lock held by the running instance.
+
 ## Usage
 
 > [!NOTE]

--- a/fixtures/next-16-static-data/.npmrc
+++ b/fixtures/next-16-static-data/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/fixtures/next-16-static-data/app/dogs/page.js
+++ b/fixtures/next-16-static-data/app/dogs/page.js
@@ -1,0 +1,54 @@
+// A statically generated page that reads a Harper table at build time. No `force-dynamic`, no
+// dynamic APIs, so Next.js prerenders it during `next build` — and Next.js runs static generation in
+// a *child process*. Loading Harper there opens the same RocksDB databases the parent Harper process
+// already has open, which without `HARPER_READONLY` fails with:
+//
+//   Error: IO error: While lock file: <root>/database/data/LOCK: Resource temporarily unavailable
+//
+// Real apps declare `harper` as a dependency and use the bare `import('harper')` specifier (see
+// HarperFast/nextjs-example). Fixtures can't: the harness deep-copies the fixture directory into the
+// Harper root and `harper` installs to ~577MB. So the test passes harper's already-resolved entry
+// path in via `HARPER_FIXTURE_HARPER_ENTRY`. The mechanism under test is unchanged — a build child
+// process loading Harper's storage layer against a database the parent holds locked.
+const harperEntry = process.env.HARPER_FIXTURE_HARPER_ENTRY;
+
+async function listDogs() {
+	// Served from a Harper worker thread, the `tables` global is already there. In the build child it
+	// is not, and loading Harper is what installs it (and opens the databases).
+	//
+	// The ignore comments are required: both bundlers otherwise try to resolve this specifier at build
+	// time and fail with "Cannot find module as expression is too dynamic". They tell the bundler to
+	// leave the import alone and let Node resolve the absolute path at runtime.
+	if (typeof globalThis.tables === 'undefined') {
+		if (!harperEntry) {
+			throw new Error(
+				'HARPER_FIXTURE_HARPER_ENTRY is not set, so this fixture cannot load Harper outside a Harper thread. ' +
+					'It is passed in by integrationTests/next-16-static-data.pw.ts.'
+			);
+		}
+		await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ harperEntry);
+	}
+
+	// No fallback if `tables.Dog` is missing, deliberately. An empty list is a *meaningful* result here
+	// — it is what a read-only child renders when it can't see the parent's unflushed writes — so
+	// swallowing a failure to load Harper as `[]` would make this test pass for the wrong reason.
+	const dogs = [];
+	for await (const dog of globalThis.tables.Dog.search()) {
+		dogs.push({ id: dog.id, name: dog.name });
+	}
+	return dogs;
+}
+
+export default async function Page() {
+	const dogs = await listDogs();
+
+	return (
+		<ul data-testid="dogs">
+			{dogs.map((dog) => (
+				<li key={dog.id} data-testid={`dog-${dog.id}`}>
+					{dog.name}
+				</li>
+			))}
+		</ul>
+	);
+}

--- a/fixtures/next-16-static-data/app/layout.js
+++ b/fixtures/next-16-static-data/app/layout.js
@@ -1,0 +1,11 @@
+export const metadata = {
+	title: 'Harper - Next.js v16 Static Data App',
+};
+
+export default function RootLayout({ children }) {
+	return (
+		<html>
+			<body>{children}</body>
+		</html>
+	);
+}

--- a/fixtures/next-16-static-data/app/page.js
+++ b/fixtures/next-16-static-data/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+	return <h1>Next.js v16 Static Data</h1>;
+}

--- a/fixtures/next-16-static-data/config.yaml
+++ b/fixtures/next-16-static-data/config.yaml
@@ -1,0 +1,12 @@
+rest: true
+
+graphqlSchema:
+  files: schema.graphql
+
+# Seeds the Dog table. Declared before @harperfast/nextjs so the row is committed by the time the
+# plugin runs `next build` — the statically generated /dogs page reads it during prerender.
+jsResource:
+  files: seed.js
+
+'@harperfast/nextjs':
+  package: '@harperfast/nextjs'

--- a/fixtures/next-16-static-data/next.config.mjs
+++ b/fixtures/next-16-static-data/next.config.mjs
@@ -1,0 +1,3 @@
+import { withHarper } from '@harperfast/nextjs';
+
+export default withHarper({});

--- a/fixtures/next-16-static-data/package.json
+++ b/fixtures/next-16-static-data/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "next-16-static-data",
+	"private": true,
+	"scripts": {
+		"dev": "next dev",
+		"build": "next build",
+		"start": "next start",
+		"lint": "next lint"
+	},
+	"dependencies": {
+		"@harperfast/nextjs": "file:../../",
+		"react": "^19",
+		"react-dom": "^19",
+		"next": "^16"
+	}
+}

--- a/fixtures/next-16-static-data/schema.graphql
+++ b/fixtures/next-16-static-data/schema.graphql
@@ -1,0 +1,4 @@
+type Dog @table @export {
+	id: ID @primaryKey
+	name: String
+}

--- a/fixtures/next-16-static-data/seed.js
+++ b/fixtures/next-16-static-data/seed.js
@@ -1,0 +1,5 @@
+import { tables } from 'harper';
+
+// Top-level await: Harper awaits component module evaluation, so the row is committed before the
+// '@harperfast/nextjs' plugin (declared after this file in config.yaml) starts `next build`.
+await tables.Dog.put({ id: 'rex', name: 'Rex' });

--- a/integrationTests/fixture.ts
+++ b/integrationTests/fixture.ts
@@ -15,10 +15,27 @@ function getHarperBinPath(): string {
 	return join(dirname(require.resolve('harper')), 'bin', 'harper.js');
 }
 
+/**
+ * Absolute path to Harper's module entry, for fixtures whose app code needs to import Harper from a
+ * `next build` child process. Fixtures can't depend on `harper` themselves — the harness deep-copies
+ * the fixture directory and the package is ~577MB — so the resolved path is passed through the
+ * environment instead. See fixtures/next-16-static-data/app/dogs/page.js.
+ */
+export function harperModuleEntry(): string {
+	return require.resolve('harper');
+}
+
 // Next.js build can take a while — give it 2 minutes.
 const STARTUP_TIMEOUT_MS = 120_000;
 
-export function makeHarperFixture(fixtureName: string) {
+export interface FixtureOptions {
+	/** Extra environment variables for the Harper process (inherited by its workers and their children). */
+	env?: Record<string, string>;
+	/** Overrides merged over the default `applications` config, e.g. `{ moduleLoader: 'native' }`. */
+	applications?: Record<string, string>;
+}
+
+export function makeHarperFixture(fixtureName: string, { env, applications }: FixtureOptions = {}) {
 	return async ({}: {}, use: (harper: HarperContext) => Promise<void>) => {
 		const fixturePath = join(import.meta.dirname, '..', 'fixtures', fixtureName);
 		const ctx = createHarperContext(fixtureName);
@@ -28,6 +45,7 @@ export function makeHarperFixture(fixtureName: string) {
 			started = await setupHarperWithFixture(ctx, fixturePath, {
 				harperBinPath: getHarperBinPath(),
 				startupTimeoutMs: STARTUP_TIMEOUT_MS,
+				...(env && { env }),
 				config: {
 					logging: {
 						stdStreams: true,
@@ -36,7 +54,8 @@ export function makeHarperFixture(fixtureName: string) {
 						lockdown: 'none',
 						moduleLoader: 'none',
 						dependencyLoader: 'native',
-						allowedDirectory: 'any'
+						allowedDirectory: 'any',
+						...applications,
 					},
 				},
 			});
@@ -55,9 +74,9 @@ export function makeHarperFixture(fixtureName: string) {
 	};
 }
 
-export function fixture(fixtureName: string) {
+export function fixture(fixtureName: string, options?: FixtureOptions) {
 	const test = base.extend<{}, { harper: HarperContext }>({
-		harper: [makeHarperFixture(fixtureName), { scope: 'worker', timeout: 120_000 }],
+		harper: [makeHarperFixture(fixtureName, options), { scope: 'worker', timeout: 120_000 }],
 	});
 	return { test, expect };
 }

--- a/integrationTests/next-16-static-data-native.pw.ts
+++ b/integrationTests/next-16-static-data-native.pw.ts
@@ -1,0 +1,32 @@
+import { fixture, harperModuleEntry } from './fixture.ts';
+
+// The same fixture as next-16-static-data.pw.ts, under `applications.moduleLoader: native`.
+//
+// Harper's default VM loader hands components a `harper` module built from a fixed allowlist
+// (`getHarperExports` in harper's security/jsLoader.ts) that omits `flushDatabases`, so the plugin's
+// pre-build flush is a no-op and a read-only build child can't see writes the parent hasn't flushed.
+// `native` mode skips the VM loader entirely and resolves the real package, so the flush runs — which
+// makes this the only place the suite actually covers `flushDatabases()` doing its job.
+//
+// The trade-off is real and documented: native mode gives up per-app tagged logging and `config`.
+const { test, expect } = fixture('next-16-static-data', {
+	env: { HARPER_FIXTURE_HARPER_ENTRY: harperModuleEntry() },
+	applications: { moduleLoader: 'native' },
+});
+
+// The counterpart to 'without a reachable flush...' in next-16-static-data.pw.ts: same page, same
+// seeded row, but the flush ran before `next build`, so the statically generated page sees the row.
+test('a reachable flush lets the build child see writes committed before the build', async ({ page, harper }) => {
+	await page.goto(`${harper.httpURL}/dogs`);
+	await expect(page.getByTestId('dog-rex')).toHaveText('Rex');
+});
+
+test('Harper still accepts writes after the build', async ({ request, harper }) => {
+	const headers = {
+		authorization: `Basic ${Buffer.from(`${harper.admin.username}:${harper.admin.password}`).toString('base64')}`,
+		'content-type': 'application/json',
+	};
+
+	const response = await request.put(`${harper.httpURL}/Dog/fido`, { data: { name: 'Fido' }, headers });
+	expect(response.ok()).toBe(true);
+});

--- a/integrationTests/next-16-static-data.pw.ts
+++ b/integrationTests/next-16-static-data.pw.ts
@@ -1,0 +1,51 @@
+import { fixture, harperModuleEntry } from './fixture.ts';
+
+// Regression coverage for Harper read-only mode during `next build`.
+//
+// Next.js runs static generation in child processes. When a prerendered page reads Harper data, that
+// child loads Harper's storage layer and opens the same RocksDB databases the parent Harper process
+// already holds — which fails on the LOCK file unless the build sets `HARPER_READONLY`. Every other
+// fixture either never touches Harper data or marks its data pages `force-dynamic`, so nothing else
+// in this suite covers the build-time path.
+const { test, expect } = fixture('next-16-static-data', {
+	env: { HARPER_FIXTURE_HARPER_ENTRY: harperModuleEntry() },
+});
+
+test('home page renders', async ({ page, harper }) => {
+	await page.goto(harper.httpURL);
+	await expect(page.locator('h1')).toHaveText('Next.js v16 Static Data');
+});
+
+// The core assertion. Without `HARPER_READONLY` the prerender of /dogs throws on the RocksDB LOCK,
+// `next build` exits non-zero, and the plugin never reaches `serve()` — so no route exists at all and
+// this fails on a connection error rather than a missing element. Reaching a rendered list means the
+// build child opened the locked databases read-only.
+test('statically generated page builds while Harper holds the databases open', async ({ page, harper }) => {
+	await page.goto(`${harper.httpURL}/dogs`);
+	await expect(page.getByTestId('dogs')).toBeAttached();
+});
+
+// Documents the flush gap under the default (VM) loader, rather than skipping it. Harper's component
+// `harper` module is a fixed allowlist (security/jsLoader.ts) that omits `flushDatabases`, so the
+// pre-build flush is a no-op here: the read-only child reads on-disk state and prerenders an empty
+// list even though `GET /Dog/rex` returns Rex. next-16-static-data-native.pw.ts runs the same fixture
+// with `moduleLoader: native`, where the flush does run and the row *is* visible.
+test('without a reachable flush, the build child does not see unflushed writes', async ({ page, harper }) => {
+	await page.goto(`${harper.httpURL}/dogs`);
+	await expect(page.getByTestId('dogs')).toBeEmpty();
+});
+
+// The build must not leave the serving process read-only, or writes after the build fail.
+test('Harper still accepts writes after the build', async ({ request, harper }) => {
+	const headers = {
+		authorization: `Basic ${Buffer.from(`${harper.admin.username}:${harper.admin.password}`).toString('base64')}`,
+		'content-type': 'application/json',
+	};
+
+	const response = await request.put(`${harper.httpURL}/Dog/fido`, { data: { name: 'Fido' }, headers });
+	expect(response.ok()).toBe(true);
+
+	const created = await request.get(`${harper.httpURL}/Dog/fido`, { headers });
+	expect(created.status()).toBe(200);
+	expect((await created.json()).name).toBe('Fido');
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@harperfast/integration-testing": "0.7.0",
-				"@playwright/test": "1.61.1",
+				"@playwright/test": "1.62.0",
 				"@types/node": "^26",
 				"harper": "5.1.23",
 				"next-14": "npm:next@14.2.35",
@@ -34,6 +34,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
 			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -82,6 +83,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -104,6 +106,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -126,6 +129,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -142,6 +146,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -158,6 +163,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -174,6 +180,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -190,6 +197,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -206,6 +214,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -222,6 +231,7 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -238,6 +248,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -254,6 +265,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -270,6 +282,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -286,6 +299,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -308,6 +322,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -330,6 +345,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -352,6 +368,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -374,6 +391,7 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -396,6 +414,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -418,6 +437,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -440,6 +460,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -462,6 +483,7 @@
 			"cpu": [
 				"wasm32"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
 			"optional": true,
 			"dependencies": {
@@ -481,6 +503,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -500,6 +523,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -519,6 +543,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -683,19 +708,19 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.61.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-			"integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+			"integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.61.1"
+				"playwright": "1.62.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@swc/counter": {
@@ -912,6 +937,7 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -2724,9 +2750,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2744,9 +2767,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2764,9 +2784,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2784,9 +2801,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -11675,35 +11689,35 @@
 			"license": "ISC"
 		},
 		"node_modules/playwright": {
-			"version": "1.61.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+			"integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.61.1"
+				"playwright-core": "1.62.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"optionalDependencies": {
 				"fsevents": "2.3.2"
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.61.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+			"integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/postcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
 			"version": "2.2.1",
 			"license": "Apache-2.0",
 			"devDependencies": {
-				"@harperfast/integration-testing": "0.3.1",
-				"@playwright/test": "1.59.1",
-				"@types/node": "^20",
-				"harper": "5.0.9",
+				"@harperfast/integration-testing": "0.7.0",
+				"@playwright/test": "1.61.1",
+				"@types/node": "^26",
+				"harper": "5.1.23",
 				"next-14": "npm:next@14.2.35",
 				"next-15": "npm:next@15.5.15",
 				"next-16": "npm:next@16.2.4",
@@ -30,1545 +30,20 @@
 				}
 			}
 		},
-		"node_modules/@agoric/babel-generator": {
-			"version": "7.17.6",
-			"resolved": "https://registry.npmjs.org/@agoric/babel-generator/-/babel-generator-7.17.6.tgz",
-			"integrity": "sha512-D2wnk5fGajxMN5SCRSaA/triQGEaEX2Du0EzrRqobuD4wRXjvtF1e7jC1PPOk/RC2bZ8/0fzp0CHOiB7YLwb5w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/types": "^7.17.0",
-				"jsesc": "^2.5.1",
-				"source-map": "^0.5.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@agoric/babel-generator/node_modules/source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@aws-crypto/crc32": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
-			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/util": "^5.2.0",
-				"@aws-sdk/types": "^3.222.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/crc32c": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
-			"integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/util": "^5.2.0",
-				"@aws-sdk/types": "^3.222.0",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@aws-crypto/sha1-browser": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
-			"integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/supports-web-crypto": "^5.2.0",
-				"@aws-crypto/util": "^5.2.0",
-				"@aws-sdk/types": "^3.222.0",
-				"@aws-sdk/util-locate-window": "^3.0.0",
-				"@smithy/util-utf8": "^2.0.0",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/is-array-buffer": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/util-buffer-from": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha256-browser": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/sha256-js": "^5.2.0",
-				"@aws-crypto/supports-web-crypto": "^5.2.0",
-				"@aws-crypto/util": "^5.2.0",
-				"@aws-sdk/types": "^3.222.0",
-				"@aws-sdk/util-locate-window": "^3.0.0",
-				"@smithy/util-utf8": "^2.0.0",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/is-array-buffer": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/util-buffer-from": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha256-js": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/util": "^5.2.0",
-				"@aws-sdk/types": "^3.222.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/supports-web-crypto": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@aws-crypto/util": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.222.0",
-				"@smithy/util-utf8": "^2.0.0",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/is-array-buffer": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/util-buffer-from": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-s3": {
-			"version": "3.1040.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1040.0.tgz",
-			"integrity": "sha512-Ldfby1xDrlZwNY2NxP9pwdVrf8sqHbGBKP1UkoG/oWcePGlGhjY8iVwy8hRy9f1EQfHVFWIFunwHaPQxhYTnWQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/sha1-browser": "5.2.0",
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.7",
-				"@aws-sdk/credential-provider-node": "^3.972.38",
-				"@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
-				"@aws-sdk/middleware-expect-continue": "^3.972.10",
-				"@aws-sdk/middleware-flexible-checksums": "^3.974.15",
-				"@aws-sdk/middleware-host-header": "^3.972.10",
-				"@aws-sdk/middleware-location-constraint": "^3.972.10",
-				"@aws-sdk/middleware-logger": "^3.972.10",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
-				"@aws-sdk/middleware-sdk-s3": "^3.972.36",
-				"@aws-sdk/middleware-ssec": "^3.972.10",
-				"@aws-sdk/middleware-user-agent": "^3.972.37",
-				"@aws-sdk/region-config-resolver": "^3.972.13",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.24",
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-endpoints": "^3.996.8",
-				"@aws-sdk/util-user-agent-browser": "^3.972.10",
-				"@aws-sdk/util-user-agent-node": "^3.973.23",
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/core": "^3.23.17",
-				"@smithy/eventstream-serde-browser": "^4.2.14",
-				"@smithy/eventstream-serde-config-resolver": "^4.3.14",
-				"@smithy/eventstream-serde-node": "^4.2.14",
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/hash-blob-browser": "^4.2.15",
-				"@smithy/hash-node": "^4.2.14",
-				"@smithy/hash-stream-node": "^4.2.14",
-				"@smithy/invalid-dependency": "^4.2.14",
-				"@smithy/md5-js": "^4.2.14",
-				"@smithy/middleware-content-length": "^4.2.14",
-				"@smithy/middleware-endpoint": "^4.4.32",
-				"@smithy/middleware-retry": "^4.5.7",
-				"@smithy/middleware-serde": "^4.2.20",
-				"@smithy/middleware-stack": "^4.2.14",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/node-http-handler": "^4.6.1",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.49",
-				"@smithy/util-defaults-mode-node": "^4.2.54",
-				"@smithy/util-endpoints": "^3.4.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.6",
-				"@smithy/util-stream": "^4.5.25",
-				"@smithy/util-utf8": "^4.2.2",
-				"@smithy/util-waiter": "^4.3.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/core": {
-			"version": "3.974.7",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.7.tgz",
-			"integrity": "sha512-YhRC90ofz5oolTJZlA8voU/oUrCB2azi8Usx51k8hhB5LpWbYQMMXKUqSqkoL0Cru+RQJgWTHpAfEDDIwfUhJw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/xml-builder": "^3.972.22",
-				"@smithy/core": "^3.23.17",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.6",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/crc64-nvme": {
-			"version": "3.972.7",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.7.tgz",
-			"integrity": "sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.33.tgz",
-			"integrity": "sha512-bJV7eViSJV6GSuuN+VIdNVPdwPsNSf75BiC2v5alPrjR/OCcqgKwSZInKbDFz9mNeizldsyf67jt6YSIiv53Cw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.7",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.35",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.35.tgz",
-			"integrity": "sha512-x/BQGEIdq0oI+4WxLjKmnQvT7CnF9r8ezdGt7wXwxb7ckHXQz0Zmgxt8v3Ne0JaT3R5YefmuybHX6E8EnsDXyA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.7",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/node-http-handler": "^4.6.1",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-stream": "^4.5.25",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.37",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.37.tgz",
-			"integrity": "sha512-eUTpmWfd/BKsq9medhCRcu+GRAhFP2Zrn7/2jKDHHOOjCkhrMoTp/t4cEthqFoG7gE0VGp5wUxrXTdvBCmSmJg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.7",
-				"@aws-sdk/credential-provider-env": "^3.972.33",
-				"@aws-sdk/credential-provider-http": "^3.972.35",
-				"@aws-sdk/credential-provider-login": "^3.972.37",
-				"@aws-sdk/credential-provider-process": "^3.972.33",
-				"@aws-sdk/credential-provider-sso": "^3.972.37",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.37",
-				"@aws-sdk/nested-clients": "^3.997.5",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/credential-provider-imds": "^4.2.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.37",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.37.tgz",
-			"integrity": "sha512-Ty68y8ISSC+g5Q3D0K8uAaoINwvfaOslnNpsF/LgVUxyosYXHawcK2yV4HLXDVugiTTYLQfJfcw0ce5meAGkKw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.7",
-				"@aws-sdk/nested-clients": "^3.997.5",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.38",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.38.tgz",
-			"integrity": "sha512-BQ9XYnBDVxR2HuV5huXYQYF/PZMTsY+EnwfGnCU2cA8Zw63XpkOtPY8WqiMIZMQCrKPQQEiFURS/o9CIolRLqg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.33",
-				"@aws-sdk/credential-provider-http": "^3.972.35",
-				"@aws-sdk/credential-provider-ini": "^3.972.37",
-				"@aws-sdk/credential-provider-process": "^3.972.33",
-				"@aws-sdk/credential-provider-sso": "^3.972.37",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.37",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/credential-provider-imds": "^4.2.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.33.tgz",
-			"integrity": "sha512-yfjGksI9WQbdMObb0VeLXqzTLI+a0qXLJT9gCDiv0+X/xjPpI3mTz6a5FibrhpuEKIe0gSgvs3MaoFZy5cx4WA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.7",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.37",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.37.tgz",
-			"integrity": "sha512-fpwE+20ntpp3i9Xb9vUuQfXLDKYHH+5I2V+ZG96SX1nBzrruhy10RXDgmN7t1etOz3c55stlA3TeQASUA451NQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.7",
-				"@aws-sdk/nested-clients": "^3.997.5",
-				"@aws-sdk/token-providers": "3.1039.0",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.37",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.37.tgz",
-			"integrity": "sha512-aryawqyebf+3WhAFNHfF62rekFpYtVcVN7dQ89qnAWsa4n5hJst8qBG6gXC24WHtW7Nnhkf9ScYnjwo0Brn3bw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.7",
-				"@aws-sdk/nested-clients": "^3.997.5",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/lib-storage": {
-			"version": "3.1024.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1024.0.tgz",
-			"integrity": "sha512-5zZSYI8VncyiatvEn+UqElvgX14NKEc+3a+aeMyMzqKuYgDCFd97KGdbqAXEgnfEiTNK0QgSecFC6PUMAsE3xg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/middleware-endpoint": "^4.4.28",
-				"@smithy/protocol-http": "^5.3.12",
-				"@smithy/smithy-client": "^4.12.8",
-				"@smithy/types": "^4.13.1",
-				"buffer": "5.6.0",
-				"events": "3.3.0",
-				"stream-browserify": "3.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			},
-			"peerDependencies": {
-				"@aws-sdk/client-s3": "^3.1024.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-bucket-endpoint": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.10.tgz",
-			"integrity": "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-arn-parser": "^3.972.3",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-config-provider": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-expect-continue": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.10.tgz",
-			"integrity": "sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-flexible-checksums": {
-			"version": "3.974.15",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.15.tgz",
-			"integrity": "sha512-j4Zp7rA1HfhDTteICnx/tPax4N/v5wmytgguXExUGyEwQ8Ug4EBA4kjp9puFAN1UZoBVpxoiXMiuTFvjaHjeEw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/crc32": "5.2.0",
-				"@aws-crypto/crc32c": "5.2.0",
-				"@aws-crypto/util": "5.2.0",
-				"@aws-sdk/core": "^3.974.7",
-				"@aws-sdk/crc64-nvme": "^3.972.7",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/is-array-buffer": "^4.2.2",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-stream": "^4.5.25",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-			"integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-location-constraint": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz",
-			"integrity": "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-			"integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.972.11",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-			"integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@aws/lambda-invoke-store": "^0.2.2",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-sdk-s3": {
-			"version": "3.972.36",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.36.tgz",
-			"integrity": "sha512-YhPix+0x/MdQrb1Ug1GDKeS5fqylIy+naz800asX8II4jqfTk2KY2KhmmYCwZcky8YWtRQQwWCGdoqeAnip8Uw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.7",
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-arn-parser": "^3.972.3",
-				"@smithy/core": "^3.23.17",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-config-provider": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-stream": "^4.5.25",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-ssec": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz",
-			"integrity": "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.972.37",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.37.tgz",
-			"integrity": "sha512-N1oNpdiLoVAWYD3WFBnUi3LlfoDA06ZHo4ozyjbsJNLvILzvt//0CnR8N+CZ0NWeYgVB/5V59ivixHCWCx2ALw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.7",
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-endpoints": "^3.996.8",
-				"@smithy/core": "^3.23.17",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-retry": "^4.3.6",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.5",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.5.tgz",
-			"integrity": "sha512-jGFr6DxtcMTmzOkG/a0jCZYv4BBDmeNYVeO+/memSoDkYCJu4Y58xviYmzwJfYyIVSts+X/BVjJm1uGBnwHEMg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.7",
-				"@aws-sdk/middleware-host-header": "^3.972.10",
-				"@aws-sdk/middleware-logger": "^3.972.10",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
-				"@aws-sdk/middleware-user-agent": "^3.972.37",
-				"@aws-sdk/region-config-resolver": "^3.972.13",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.24",
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-endpoints": "^3.996.8",
-				"@aws-sdk/util-user-agent-browser": "^3.972.10",
-				"@aws-sdk/util-user-agent-node": "^3.973.23",
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/core": "^3.23.17",
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/hash-node": "^4.2.14",
-				"@smithy/invalid-dependency": "^4.2.14",
-				"@smithy/middleware-content-length": "^4.2.14",
-				"@smithy/middleware-endpoint": "^4.4.32",
-				"@smithy/middleware-retry": "^4.5.7",
-				"@smithy/middleware-serde": "^4.2.20",
-				"@smithy/middleware-stack": "^4.2.14",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/node-http-handler": "^4.6.1",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.49",
-				"@smithy/util-defaults-mode-node": "^4.2.54",
-				"@smithy/util-endpoints": "^3.4.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.6",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.972.13",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-			"integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.24",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.24.tgz",
-			"integrity": "sha512-amP7tLikppN940wbBFISYqiuzVmpzMS9U3mcgtmVLjX4fdWI/SNCvrXv6ZxfVzTT4cT0rPKOLhFah2xLwzREWw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/middleware-sdk-s3": "^3.972.36",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.1039.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1039.0.tgz",
-			"integrity": "sha512-NMSFL2HwkAOoCeLCQiqoOq5pT3vVbSjww2QZTuYgYknVwhhv125PSDzZIcL5EYnlxuPWjEOdauZK+FspkZDVdw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.7",
-				"@aws-sdk/nested-clients": "^3.997.5",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/types": {
-			"version": "3.973.8",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-			"integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-arn-parser": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
-			"integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.996.8",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-			"integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-endpoints": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-locate-window": {
-			"version": "3.965.5",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-			"integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/types": "^4.14.1",
-				"bowser": "^2.11.0",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.973.23",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.23.tgz",
-			"integrity": "sha512-gGwq8L2Euw0aNG6Ey4EktiAo3fSCVoDy1CaBIthd+oeaKHPXUrNaApMewQ6La5Hv0lcznOtECZaNvYyc5LXXfA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "^3.972.37",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-config-provider": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			},
-			"peerDependencies": {
-				"aws-crt": ">=1.0.0"
-			},
-			"peerDependenciesMeta": {
-				"aws-crt": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.22",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
-			"integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@nodable/entities": "2.1.0",
-				"@smithy/types": "^4.14.1",
-				"fast-xml-parser": "5.7.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws/lambda-invoke-store": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@babel/code-frame": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.28.5",
-				"js-tokens": "^4.0.0",
-				"picocolors": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/generator": {
-			"version": "7.29.1",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.29.0",
-				"@babel/types": "^7.29.0",
-				"@jridgewell/gen-mapping": "^0.3.12",
-				"@jridgewell/trace-mapping": "^0.3.28",
-				"jsesc": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/generator/node_modules/jsesc": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"jsesc": "bin/jsesc"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@babel/helper-globals": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/parser": {
-			"version": "7.29.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-			"integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/types": "^7.29.0"
-			},
-			"bin": {
-				"parser": "bin/babel-parser.js"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@babel/runtime": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/template": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.28.6",
-				"@babel/parser": "^7.28.6",
-				"@babel/types": "^7.28.6"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/traverse": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.29.0",
-				"debug": "^4.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/types": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.28.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.2.2.tgz",
-			"integrity": "sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@cbor-extract/cbor-extract-darwin-x64": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.2.2.tgz",
-			"integrity": "sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@cbor-extract/cbor-extract-linux-arm": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.2.2.tgz",
-			"integrity": "sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@cbor-extract/cbor-extract-linux-arm64": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.2.2.tgz",
-			"integrity": "sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@cbor-extract/cbor-extract-linux-x64": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.2.2.tgz",
-			"integrity": "sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@cbor-extract/cbor-extract-win32-x64": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.2.2.tgz",
-			"integrity": "sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@colors/colors": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.1.90"
-			}
-		},
-		"node_modules/@datadog/pprof": {
-			"version": "5.14.1",
-			"resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.14.1.tgz",
-			"integrity": "sha512-MlODCE9Gltmx7WChOg1BkIm7W2iE4CDW7K72BMwgzCvxFkG9rFWVsuA7/NEZL1nDvJ0qDe2du7DZZdZHTjcVPw==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"node-gyp-build": "<4.0",
-				"pprof-format": "^2.2.1",
-				"source-map": "^0.7.4"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
 		"node_modules/@emnapi/runtime": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
 			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
 		},
-		"node_modules/@endo/cache-map": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@endo/cache-map/-/cache-map-1.1.0.tgz",
-			"integrity": "sha512-owFGshs/97PDw9oguZqU/px8Lv1d0KjAUtDUiPwKHNXRVUE/jyettEbRoTbNJR1OaI8biMn6bHr9kVJsOh6dXw==",
-			"dev": true,
-			"license": "Apache-2.0"
-		},
-		"node_modules/@endo/env-options": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/@endo/env-options/-/env-options-1.1.11.tgz",
-			"integrity": "sha512-p9OnAPsdqoX4YJsE98e3NBVhIr2iW9gNZxHhAI2/Ul5TdRfoOViItzHzTqrgUVopw6XxA1u1uS6CykLMDUxarA==",
-			"dev": true,
-			"license": "Apache-2.0"
-		},
-		"node_modules/@endo/immutable-arraybuffer": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@endo/immutable-arraybuffer/-/immutable-arraybuffer-1.1.2.tgz",
-			"integrity": "sha512-u+NaYB2aqEugQ3u7w3c5QNkPogf8q/xGgsPaqdY6pUiGWtYiTiFspKFcha6+oeZhWXWQ23rf0KrUq0kfuzqYyQ==",
-			"dev": true,
-			"license": "Apache-2.0"
-		},
-		"node_modules/@endo/static-module-record": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@endo/static-module-record/-/static-module-record-1.1.2.tgz",
-			"integrity": "sha512-Rzw6r/tdN6vsqZJRUcItNpZXy4qTtSRy0nCm52p/4rz3MNIiMd/Jfth+Etm0q4klhEMWLnBxSY80hnESfBzkqw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@agoric/babel-generator": "^7.17.6",
-				"@babel/parser": "^7.23.6",
-				"@babel/traverse": "^7.23.6",
-				"@babel/types": "^7.24.0",
-				"ses": "^1.5.0"
-			}
-		},
-		"node_modules/@epic-web/invariant": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
-			"integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@fastify/accept-negotiator": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-2.0.1.tgz",
-			"integrity": "sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/@fastify/ajv-compiler": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
-			"integrity": "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"ajv": "^8.12.0",
-				"ajv-formats": "^3.0.1",
-				"fast-uri": "^3.0.0"
-			}
-		},
-		"node_modules/@fastify/autoload": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/@fastify/autoload/-/autoload-6.3.1.tgz",
-			"integrity": "sha512-0fsG+lO3m5yEZVjXKpltCe+2eHhM6rfAPQhvlGUgLUFTw/N2wA9WqPTObMtrF3oUCUrxbSDv60HlUIoh+aFM1A==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/@fastify/compress": {
-			"version": "8.3.1",
-			"resolved": "https://registry.npmjs.org/@fastify/compress/-/compress-8.3.1.tgz",
-			"integrity": "sha512-BUpItLr6MUX9e9ukg5Y6xekyA/7pBFG8QWtFCrUDm9ctoBc3R2/nA16yOaOWtVoccpXGjdDEYA/MxAb5+8cxag==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@fastify/accept-negotiator": "^2.0.0",
-				"fastify-plugin": "^5.0.0",
-				"mime-db": "^1.52.0",
-				"minipass": "^7.0.4",
-				"peek-stream": "^1.1.3",
-				"pump": "^3.0.0",
-				"pumpify": "^2.0.1",
-				"readable-stream": "^4.5.2"
-			}
-		},
-		"node_modules/@fastify/cors": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-11.2.0.tgz",
-			"integrity": "sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"fastify-plugin": "^5.0.0",
-				"toad-cache": "^3.7.0"
-			}
-		},
-		"node_modules/@fastify/error": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
-			"integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/@fastify/fast-json-stringify-compiler": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.0.3.tgz",
-			"integrity": "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"fast-json-stringify": "^6.0.0"
-			}
-		},
-		"node_modules/@fastify/forwarded": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
-			"integrity": "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/@fastify/merge-json-schemas": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
-			"integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"node_modules/@fastify/proxy-addr": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
-			"integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@fastify/forwarded": "^3.0.0",
-				"ipaddr.js": "^2.1.0"
-			}
-		},
-		"node_modules/@fastify/send": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@fastify/send/-/send-4.1.0.tgz",
-			"integrity": "sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@lukeed/ms": "^2.0.2",
-				"escape-html": "~1.0.3",
-				"fast-decode-uri-component": "^1.0.1",
-				"http-errors": "^2.0.0",
-				"mime": "^3"
-			}
-		},
-		"node_modules/@fastify/static": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.3.tgz",
-			"integrity": "sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@fastify/accept-negotiator": "^2.0.0",
-				"@fastify/send": "^4.0.0",
-				"content-disposition": "^1.0.1",
-				"fastify-plugin": "^5.0.0",
-				"fastq": "^1.17.1",
-				"glob": "^13.0.0"
-			}
-		},
-		"node_modules/@hapi/hoek": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-			"integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@hapi/topo": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-			"integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@hapi/hoek": "^9.0.0"
-			}
-		},
-		"node_modules/@harperfast/extended-iterable": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@harperfast/extended-iterable/-/extended-iterable-1.0.3.tgz",
-			"integrity": "sha512-sSAYhQca3rDWtQUHSAPeO7axFIUJOI6hn1gjRC5APVE1a90tuyT8f5WIgRsFhhWA7htNkju2veB9eWL6YHi/Lw==",
-			"dev": true,
-			"license": "Apache-2.0"
-		},
 		"node_modules/@harperfast/integration-testing": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/integration-testing/-/integration-testing-0.3.1.tgz",
-			"integrity": "sha512-hW7XsSTRWv38pK0nY4GZhGmmWAeQg/2eSSHAdwOO+niL7QORLExGjKCYxySylpKbWRdORQ7JjG5RMkFH+LQc9g==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/integration-testing/-/integration-testing-0.7.0.tgz",
+			"integrity": "sha512-uLa+aYJpKWNzODqny9zBfsZa/5SL/qEMq3x9RxWjZYtVcKUtq76rzfc5mNjdpBPv+3MUmy8DALzF7ajShbKJjA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -1590,177 +65,6 @@
 				}
 			}
 		},
-		"node_modules/@harperfast/rocksdb-js": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-1.1.1.tgz",
-			"integrity": "sha512-KlpkEESg7dPjaSCECFP0fOjZh36X7ckHG8gnRj3EQZHOUf9bBPS5dfu4UdtMKOnd7VfzogKiAOrhJaOPqqrJaA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@harperfast/extended-iterable": "1.0.3",
-				"msgpackr": "1.11.10",
-				"ordered-binary": "1.6.1"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"@harperfast/rocksdb-js-darwin-arm64": "1.1.1",
-				"@harperfast/rocksdb-js-darwin-x64": "1.1.1",
-				"@harperfast/rocksdb-js-linux-arm64-glibc": "1.1.1",
-				"@harperfast/rocksdb-js-linux-arm64-musl": "1.1.1",
-				"@harperfast/rocksdb-js-linux-x64-glibc": "1.1.1",
-				"@harperfast/rocksdb-js-linux-x64-musl": "1.1.1",
-				"@harperfast/rocksdb-js-win32-arm64": "1.1.1",
-				"@harperfast/rocksdb-js-win32-x64": "1.1.1"
-			}
-		},
-		"node_modules/@harperfast/rocksdb-js-darwin-arm64": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-1.1.1.tgz",
-			"integrity": "sha512-lisyo7P9Rcu/keml+w/iqxrasZbuqOqyVYfdFMnO5YRNbMpMRufVrYw4VJURx41KQ1P2odAUqHUwPS2TcBMI0Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@harperfast/rocksdb-js-darwin-x64": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-1.1.1.tgz",
-			"integrity": "sha512-sCS+xo97bjK3JClcwVybGcQLh3Qxp30onSSL67NHYsMvQRyW2Fft3NYPq9YWEqRyhhXnsr2F9biQj6/dNnRelA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@harperfast/rocksdb-js-linux-arm64-glibc": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-1.1.1.tgz",
-			"integrity": "sha512-koyTqfdtjmaT+D89AzzuqwEMGTxV4cysJjsMdPIm+5Bbv7+pg19thY4jtO60wJx6lsq7bu7CJ+/9iLTsPge09A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@harperfast/rocksdb-js-linux-arm64-musl": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-1.1.1.tgz",
-			"integrity": "sha512-HnWUhjO5MZ/FBSxJkuG/9V1ihjFIpy7bYPvKLVNzRNmWj+oJEZC8BVVyf+HkDweqPNttTmAA6poM/K/U+S8mgA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@harperfast/rocksdb-js-linux-x64-glibc": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-1.1.1.tgz",
-			"integrity": "sha512-Yws3BMQl1ZpfZVQLXwuylx/VLCzYxnIhg8u8upvnLERf5pVGsYs5ES98IFbnFyipFS0nIHwszQIKGAugnIpNsA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@harperfast/rocksdb-js-linux-x64-musl": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-1.1.1.tgz",
-			"integrity": "sha512-0kRhi5xOtkZd6bzrZ4BwrPuL7Pj7UWqOEoWdC45B9HaQo5PJiV/7oev5pw6cyv4k4vLA5Gd5kV18QIIbKEKoSw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@harperfast/rocksdb-js-win32-arm64": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-1.1.1.tgz",
-			"integrity": "sha512-ODgYMsjfJ23oCGyj/0XW8OX1D48FLcnuZ+g+5hxi/6od2a/ycX/AEfECRkX2+jRsYMPJwk2lrrmwdD78pZXA1g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@harperfast/rocksdb-js-win32-x64": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-1.1.1.tgz",
-			"integrity": "sha512-mRojPy4rczwMFIlPqRjGAxGHjjQ0/b8O4o49lGdQ7oIMo9Jguqbg9bDMoReMAjM5HQccfb5HbeF4rx0cy6SuQg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@harperfast/rocksdb-js/node_modules/msgpackr": {
-			"version": "1.11.10",
-			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.10.tgz",
-			"integrity": "sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==",
-			"dev": true,
-			"license": "MIT",
-			"optionalDependencies": {
-				"msgpackr-extract": "^3.0.2"
-			}
-		},
 		"node_modules/@img/colour": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
@@ -1778,7 +82,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1801,7 +104,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1824,7 +126,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1841,7 +142,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1858,7 +158,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1875,7 +174,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1892,7 +190,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1909,7 +206,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1926,7 +222,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1943,7 +238,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1960,7 +254,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1977,7 +270,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1994,7 +286,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2017,7 +308,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2040,7 +330,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2063,7 +352,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2086,7 +374,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2109,7 +396,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2132,7 +418,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2155,7 +440,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2178,7 +462,6 @@
 			"cpu": [
 				"wasm32"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
 			"optional": true,
 			"dependencies": {
@@ -2198,7 +481,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -2218,7 +500,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -2238,7 +519,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -2250,259 +530,6 @@
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			}
-		},
-		"node_modules/@inquirer/external-editor": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
-			"integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chardet": "^2.1.1",
-				"iconv-lite": "^0.7.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"@types/node": ">=18"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.5.0",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			}
-		},
-		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.31",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.1.0",
-				"@jridgewell/sourcemap-codec": "^1.4.14"
-			}
-		},
-		"node_modules/@lmdb/lmdb-darwin-arm64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.5.4.tgz",
-			"integrity": "sha512-Kk4Kz3iyu1QiLsLZBS9Af1eSKUC8VR2T+/jyE2iAyuGw2VwK08pp5iTbZnXn6sWu0LogO/RFktMxOjiDA2sS3w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@lmdb/lmdb-darwin-x64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-3.5.4.tgz",
-			"integrity": "sha512-BEe5Rp3trn26oxoXOVL5HVDoiYmjUDwr8NRPkBOdUdCSBEorKI+7JrZLRKAdxO+G6cGQLgseXk0gR7qIQa7aGw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@lmdb/lmdb-linux-arm": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-3.5.4.tgz",
-			"integrity": "sha512-SGbFR7816uBcTHc2ZY4S6WyOkl9bICnzqTQd2Mv4V/j24cfds88xx2nC6cm/y8zGQL7Ds31YF/5NGxjgcdM5Hw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@lmdb/lmdb-linux-arm64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-3.5.4.tgz",
-			"integrity": "sha512-cUXEengO8o60v1SWerJTH4/RH4U3+9jC0/4njp2Z9NdmvaGzhKsbRM2wpXuRYrN8tytsoJCg0SvWEWwHAwLbCA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@lmdb/lmdb-linux-x64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-3.5.4.tgz",
-			"integrity": "sha512-Gxq8jpgOWXwd0PUR+c9R2Ik1/uBnGd5GMIIzRRDqABCkvmjtC3KWcyhesV9jSPCz759isl0NlbsstZ2oyvk8lA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@lmdb/lmdb-win32-arm64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-arm64/-/lmdb-win32-arm64-3.5.4.tgz",
-			"integrity": "sha512-pKv1DJ1bPZAaHkdFsSz5IDfUG8x9vntgquXF9/Dm2xuupcIe/EkLzylpoBxppFVK5vzbV561Dq26jNY2fIMA7g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@lmdb/lmdb-win32-x64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.5.4.tgz",
-			"integrity": "sha512-JF1BmLCm9kGEVZgYmJq43zeQVdHVgAJnTi/NURWEsy6L1ZrrlSmdltS+D17QN4LODwf+1LMXAA9auIZVXtWwzw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@lukeed/ms": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
-			"integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
-			"integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
-			"integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
-			"integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
-			"integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
-			"integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
-			"integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
 		},
 		"node_modules/@next/env": {
 			"version": "16.2.4",
@@ -2655,894 +682,20 @@
 				"node": ">= 10"
 			}
 		},
-		"node_modules/@noble/hashes": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-			"integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@nodable/entities": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/nodable"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/@nodelib/fs.scandir": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.stat": "2.0.5",
-				"run-parallel": "^1.1.9"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@nodelib/fs.stat": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@nodelib/fs.walk": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.scandir": "2.1.5",
-				"fastq": "^1.6.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@phc/format": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
-			"integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@pinojs/redact": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
-			"integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@playwright/test": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+			"integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.59.1"
+				"playwright": "1.61.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/@sideway/address": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-			"integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@hapi/hoek": "^9.0.0"
-			}
-		},
-		"node_modules/@sideway/formula": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-			"integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@sideway/pinpoint": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-			"integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@smithy/chunked-blob-reader": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
-			"integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/chunked-blob-reader-native": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
-			"integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/util-base64": "^4.3.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/config-resolver": {
-			"version": "4.4.17",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
-			"integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-config-provider": "^4.2.2",
-				"@smithy/util-endpoints": "^3.4.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/core": {
-			"version": "3.23.17",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
-			"integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-stream": "^4.5.25",
-				"@smithy/util-utf8": "^4.2.2",
-				"@smithy/uuid": "^1.1.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
-			"integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-codec": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
-			"integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/crc32": "5.2.0",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-browser": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
-			"integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-config-resolver": {
-			"version": "4.3.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
-			"integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-node": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
-			"integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-universal": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
-			"integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/eventstream-codec": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.3.17",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
-			"integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/querystring-builder": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-base64": "^4.3.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/hash-blob-browser": {
-			"version": "4.2.15",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.15.tgz",
-			"integrity": "sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/chunked-blob-reader": "^5.2.2",
-				"@smithy/chunked-blob-reader-native": "^4.2.3",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/hash-node": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
-			"integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-buffer-from": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/hash-stream-node": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.14.tgz",
-			"integrity": "sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/invalid-dependency": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
-			"integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/is-array-buffer": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
-			"integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/md5-js": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.14.tgz",
-			"integrity": "sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-content-length": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
-			"integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-endpoint": {
-			"version": "4.4.32",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
-			"integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.23.17",
-				"@smithy/middleware-serde": "^4.2.20",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-middleware": "^4.2.14",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-retry": {
-			"version": "4.5.7",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
-			"integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.23.17",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/service-error-classification": "^4.3.1",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.6",
-				"@smithy/uuid": "^1.1.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-serde": {
-			"version": "4.2.20",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
-			"integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.23.17",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-stack": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
-			"integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/node-config-provider": {
-			"version": "4.3.14",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
-			"integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/node-http-handler": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
-			"integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/querystring-builder": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/property-provider": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
-			"integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/protocol-http": {
-			"version": "5.3.14",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
-			"integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/querystring-builder": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
-			"integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-uri-escape": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/querystring-parser": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
-			"integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/service-error-classification": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
-			"integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/shared-ini-file-loader": {
-			"version": "4.4.9",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
-			"integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/signature-v4": {
-			"version": "5.3.14",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
-			"integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.2",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-uri-escape": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/smithy-client": {
-			"version": "4.12.13",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
-			"integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.23.17",
-				"@smithy/middleware-endpoint": "^4.4.32",
-				"@smithy/middleware-stack": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-stream": "^4.5.25",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/types": {
-			"version": "4.14.1",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-			"integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/url-parser": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
-			"integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/querystring-parser": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-base64": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-body-length-browser": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
-			"integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-body-length-node": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
-			"integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-buffer-from": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
-			"integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-config-provider": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
-			"integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.3.49",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
-			"integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.2.54",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
-			"integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/credential-provider-imds": "^4.2.14",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-endpoints": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
-			"integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-hex-encoding": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
-			"integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-middleware": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
-			"integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-retry": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.6.tgz",
-			"integrity": "sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/service-error-classification": "^4.3.1",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-stream": {
-			"version": "4.5.25",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
-			"integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/node-http-handler": "^4.6.1",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-buffer-from": "^4.2.2",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-uri-escape": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
-			"integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-utf8": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-waiter": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.3.0.tgz",
-			"integrity": "sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/uuid": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
-			"integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@swc/counter": {
@@ -3561,521 +714,14 @@
 				"tslib": "^2.8.0"
 			}
 		},
-		"node_modules/@turf/area": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/area/-/area-6.5.0.tgz",
-			"integrity": "sha512-xCZdiuojokLbQ+29qR6qoMD89hv+JAgWjLrwSEWL+3JV8IXKeNFl6XkEJz9HGkVpnXvQKJoRz4/liT+8ZZ5Jyg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/helpers": "^6.5.0",
-				"@turf/meta": "^6.5.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/bbox": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
-			"integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/helpers": "^6.5.0",
-				"@turf/meta": "^6.5.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/boolean-contains": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-6.5.0.tgz",
-			"integrity": "sha512-4m8cJpbw+YQcKVGi8y0cHhBUnYT+QRfx6wzM4GI1IdtYH3p4oh/DOBJKrepQyiDzFDaNIjxuWXBh0ai1zVwOQQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/bbox": "^6.5.0",
-				"@turf/boolean-point-in-polygon": "^6.5.0",
-				"@turf/boolean-point-on-line": "^6.5.0",
-				"@turf/helpers": "^6.5.0",
-				"@turf/invariant": "^6.5.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/boolean-disjoint": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-6.5.0.tgz",
-			"integrity": "sha512-rZ2ozlrRLIAGo2bjQ/ZUu4oZ/+ZjGvLkN5CKXSKBcu6xFO6k2bgqeM8a1836tAW+Pqp/ZFsTA5fZHsJZvP2D5g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/boolean-point-in-polygon": "^6.5.0",
-				"@turf/helpers": "^6.5.0",
-				"@turf/line-intersect": "^6.5.0",
-				"@turf/meta": "^6.5.0",
-				"@turf/polygon-to-line": "^6.5.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/boolean-equal": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-6.5.0.tgz",
-			"integrity": "sha512-cY0M3yoLC26mhAnjv1gyYNQjn7wxIXmL2hBmI/qs8g5uKuC2hRWi13ydufE3k4x0aNRjFGlg41fjoYLwaVF+9Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/clean-coords": "^6.5.0",
-				"@turf/helpers": "^6.5.0",
-				"@turf/invariant": "^6.5.0",
-				"geojson-equality": "0.1.6"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/boolean-point-in-polygon": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.5.0.tgz",
-			"integrity": "sha512-DtSuVFB26SI+hj0SjrvXowGTUCHlgevPAIsukssW6BG5MlNSBQAo70wpICBNJL6RjukXg8d2eXaAWuD/CqL00A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/helpers": "^6.5.0",
-				"@turf/invariant": "^6.5.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/boolean-point-on-line": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-6.5.0.tgz",
-			"integrity": "sha512-A1BbuQ0LceLHvq7F/P7w3QvfpmZqbmViIUPHdNLvZimFNLo4e6IQunmzbe+8aSStH9QRZm3VOflyvNeXvvpZEQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/helpers": "^6.5.0",
-				"@turf/invariant": "^6.5.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/circle": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/circle/-/circle-6.5.0.tgz",
-			"integrity": "sha512-oU1+Kq9DgRnoSbWFHKnnUdTmtcRUMmHoV9DjTXu9vOLNV5OWtAAh1VZ+mzsioGGzoDNT/V5igbFOkMfBQc0B6A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/destination": "^6.5.0",
-				"@turf/helpers": "^6.5.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/clean-coords": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-6.5.0.tgz",
-			"integrity": "sha512-EMX7gyZz0WTH/ET7xV8MyrExywfm9qUi0/MY89yNffzGIEHuFfqwhcCqZ8O00rZIPZHUTxpmsxQSTfzJJA1CPw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/helpers": "^6.5.0",
-				"@turf/invariant": "^6.5.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/destination": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/destination/-/destination-6.5.0.tgz",
-			"integrity": "sha512-4cnWQlNC8d1tItOz9B4pmJdWpXqS0vEvv65bI/Pj/genJnsL7evI0/Xw42RvEGROS481MPiU80xzvwxEvhQiMQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/helpers": "^6.5.0",
-				"@turf/invariant": "^6.5.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/difference": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/difference/-/difference-6.5.0.tgz",
-			"integrity": "sha512-l8iR5uJqvI+5Fs6leNbhPY5t/a3vipUF/3AeVLpwPQcgmedNXyheYuy07PcMGH5Jdpi5gItOiTqwiU/bUH4b3A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/helpers": "^6.5.0",
-				"@turf/invariant": "^6.5.0",
-				"polygon-clipping": "^0.15.3"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/distance": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
-			"integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/helpers": "^6.5.0",
-				"@turf/invariant": "^6.5.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/helpers": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
-			"integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/invariant": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
-			"integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/helpers": "^6.5.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/length": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/length/-/length-6.5.0.tgz",
-			"integrity": "sha512-5pL5/pnw52fck3oRsHDcSGrj9HibvtlrZ0QNy2OcW8qBFDNgZ4jtl6U7eATVoyWPKBHszW3dWETW+iLV7UARig==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/distance": "^6.5.0",
-				"@turf/helpers": "^6.5.0",
-				"@turf/meta": "^6.5.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/line-intersect": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-6.5.0.tgz",
-			"integrity": "sha512-CS6R1tZvVQD390G9Ea4pmpM6mJGPWoL82jD46y0q1KSor9s6HupMIo1kY4Ny+AEYQl9jd21V3Scz20eldpbTVA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/helpers": "^6.5.0",
-				"@turf/invariant": "^6.5.0",
-				"@turf/line-segment": "^6.5.0",
-				"@turf/meta": "^6.5.0",
-				"geojson-rbush": "3.x"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/line-segment": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-6.5.0.tgz",
-			"integrity": "sha512-jI625Ho4jSuJESNq66Mmi290ZJ5pPZiQZruPVpmHkUw257Pew0alMmb6YrqYNnLUuiVVONxAAKXUVeeUGtycfw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/helpers": "^6.5.0",
-				"@turf/invariant": "^6.5.0",
-				"@turf/meta": "^6.5.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/meta": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
-			"integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/helpers": "^6.5.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/polygon-to-line": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-6.5.0.tgz",
-			"integrity": "sha512-5p4n/ij97EIttAq+ewSnKt0ruvuM+LIDzuczSzuHTpq4oS7Oq8yqg5TQ4nzMVuK41r/tALCk7nAoBuw3Su4Gcw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@turf/helpers": "^6.5.0",
-				"@turf/invariant": "^6.5.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@types/geojson": {
-			"version": "7946.0.8",
-			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
-			"integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/node": {
-			"version": "20.19.39",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-			"integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+			"version": "26.1.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+			"integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.21.0"
-			}
-		},
-		"node_modules/@types/readable-stream": {
-			"version": "4.0.23",
-			"resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
-			"integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/abort-controller": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"event-target-shim": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=6.5"
-			}
-		},
-		"node_modules/abstract-logging": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
-			"integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/ajv": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/ajv-formats": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ajv": "^8.0.0"
-			},
-			"peerDependencies": {
-				"ajv": "^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"ajv": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/alasql": {
-			"version": "4.6.6",
-			"resolved": "https://registry.npmjs.org/alasql/-/alasql-4.6.6.tgz",
-			"integrity": "sha512-kuRnDciFgtWSR2tpgraFwE6Q19PmeY9d2O2JzXdpEd38xoBrbp3qKDiGhzBvKfrxpuimwn+6w94FXE9NT3hJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cross-fetch": "4.1.0",
-				"yargs": "16"
-			},
-			"bin": {
-				"alasql": "bin/alasql-cli.js"
-			},
-			"engines": {
-				"node": ">=15"
-			}
-		},
-		"node_modules/amaro": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/amaro/-/amaro-1.1.9.tgz",
-			"integrity": "sha512-Qx5+iHi3mKWz95XNx/WPFl8yRMZEGNoRZDaOkoej72kxAo20FbDVx7jALcvyOn/N3+h+GboKip49yba7xqLlKA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=22"
-			}
-		},
-		"node_modules/ansi-escapes": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"type-fest": "^0.21.3"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/argon2": {
-			"version": "0.44.0",
-			"resolved": "https://registry.npmjs.org/argon2/-/argon2-0.44.0.tgz",
-			"integrity": "sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"dependencies": {
-				"@phc/format": "^1.0.0",
-				"cross-env": "^10.0.0",
-				"node-addon-api": "^8.5.0",
-				"node-gyp-build": "^4.8.4"
-			},
-			"engines": {
-				"node": ">=16.17.0"
-			}
-		},
-		"node_modules/argon2/node_modules/node-gyp-build": {
-			"version": "4.8.4",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"node-gyp-build": "bin.js",
-				"node-gyp-build-optional": "optional.js",
-				"node-gyp-build-test": "build-test.js"
-			}
-		},
-		"node_modules/asn1js": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
-			"integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"pvtsutils": "^1.3.6",
-				"pvutils": "^1.1.3",
-				"tslib": "^2.8.1"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/async": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/atomic-sleep": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
-			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/avvio": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/avvio/-/avvio-9.2.0.tgz",
-			"integrity": "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@fastify/error": "^4.0.0",
-				"fastq": "^1.17.1"
-			}
-		},
-		"node_modules/balanced-match": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "18 || 20 || >=22"
+				"undici-types": "~8.3.0"
 			}
 		},
 		"node_modules/bare-events": {
@@ -4175,27 +821,6 @@
 				"bare-path": "^3.0.0"
 			}
 		},
-		"node_modules/base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/baseline-browser-mapping": {
 			"version": "2.10.24",
 			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
@@ -4208,161 +833,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/bignumber.js": {
-			"version": "9.3.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"node_modules/bl": {
-			"version": "6.1.6",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
-			"integrity": "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/readable-stream": "^4.0.0",
-				"buffer": "^6.0.3",
-				"inherits": "^2.0.4",
-				"readable-stream": "^4.2.0"
-			}
-		},
-		"node_modules/bl/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/bowser": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
-			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^4.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/braces": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fill-range": "^7.1.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/browserify-zlib": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-			"integrity": "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"pako": "~0.2.0"
-			}
-		},
-		"node_modules/buffer": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-			"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4"
-			}
-		},
-		"node_modules/buffer-equal-constant-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/buffer-from": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/bufferutil": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
-			"integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=6.14.2"
-			}
-		},
-		"node_modules/bufferutil/node_modules/node-gyp-build": {
-			"version": "4.8.4",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"bin": {
-				"node-gyp-build": "bin.js",
-				"node-gyp-build-optional": "optional.js",
-				"node-gyp-build-test": "build-test.js"
-			}
-		},
 		"node_modules/busboy": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -4373,66 +843,6 @@
 			},
 			"engines": {
 				"node": ">=10.16.0"
-			}
-		},
-		"node_modules/bytestreamjs": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
-			"integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/call-bind": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.2",
-				"es-define-property": "^1.0.1",
-				"get-intrinsic": "^1.3.0",
-				"set-function-length": "^1.2.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/call-bind-apply-helpers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/call-bound": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.2",
-				"get-intrinsic": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/caniuse-lite": {
@@ -4455,10 +865,4257 @@
 			],
 			"license": "CC-BY-4.0"
 		},
-		"node_modules/cbor-extract": {
+		"node_modules/client-only": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+			"integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+			"license": "MIT"
+		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/events-universal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+			"integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-events": "^2.7.0"
+			}
+		},
+		"node_modules/fast-fifo": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/harper": {
+			"version": "5.1.23",
+			"resolved": "https://registry.npmjs.org/harper/-/harper-5.1.23.tgz",
+			"integrity": "sha512-GlQsABq7nzPgvGJrJfGlge/TbxwiZSA0/2InSDlVII9Sx2oFrXaJ8voiWff+cjbfdC7PR17VFtzxfWX8MPlwnw==",
+			"dev": true,
+			"hasShrinkwrap": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/client-s3": "^3.1012.0",
+				"@aws-sdk/lib-storage": "3.1075.0",
+				"@endo/static-module-record": "^1.1.2",
+				"@fastify/autoload": "^6.3.1",
+				"@fastify/compress": "^8.3.1",
+				"@fastify/cors": "^11.2.0",
+				"@fastify/static": "^9.1.3",
+				"@harperfast/extended-iterable": "^1.0.1",
+				"@harperfast/rocksdb-js": "^2.3.0",
+				"@turf/area": "6.5.0",
+				"@turf/boolean-contains": "6.5.0",
+				"@turf/boolean-disjoint": "6.5.0",
+				"@turf/boolean-equal": "6.5.0",
+				"@turf/circle": "6.5.0",
+				"@turf/difference": "6.5.0",
+				"@turf/distance": "6.5.0",
+				"@turf/helpers": "6.5.0",
+				"@turf/length": "6.5.0",
+				"alasql": "4.17.3",
+				"amaro": "^1.1.8",
+				"argon2": "0.44.0",
+				"asn1js": "3.0.10",
+				"busboy": "^1.6.0",
+				"cbor-x": "1.6.4",
+				"chalk": "4.1.2",
+				"chokidar": "^4.0.3",
+				"cli-progress": "3.12.0",
+				"clone": "2.1.2",
+				"dotenv": "^16.4.7",
+				"easy-ocsp": "1.3.2",
+				"fast-glob": "3.3.3",
+				"fastify": "^5.8.2",
+				"fastify-plugin": "^5.1.0",
+				"fs-extra": "11.3.5",
+				"graphql": "^16.10.0",
+				"graphql-http": "^1.22.4",
+				"gunzip-maybe": "1.4.2",
+				"human-readable-ids": "1.0.4",
+				"inquirer": "8.2.7",
+				"is-number": "7.0.0",
+				"joi": "17.13.4",
+				"json-bigint-fixes": "1.1.0",
+				"jsonata": "1.8.7",
+				"jsonwebtoken": "9.0.3",
+				"lmdb": "3.5.6",
+				"lodash": "^4.17.23",
+				"mathjs": "11.12.0",
+				"micromatch": "^4.0.8",
+				"minimist": "1.2.8",
+				"moment": "2.30.1",
+				"mqtt-packet": "~9.0.1",
+				"msgpackr": "^2.0.4",
+				"needle": "3.5.0",
+				"node-forge": "^1.3.1",
+				"node-stream-zip": "1.15.0",
+				"normalize-path": "^3.0.0",
+				"ora": "8.2.0",
+				"ordered-binary": "1.6.1",
+				"papaparse": "5.5.4",
+				"passport": "0.7.0",
+				"passport-http": "0.3.0",
+				"passport-local": "1.0.0",
+				"pino": "8.21.0",
+				"pkijs": "3.4.0",
+				"prompt": "1.3.0",
+				"properties-reader": "2.3.0",
+				"recursive-iterator": "3.3.0",
+				"semver": "7.8.5",
+				"send": "^1.2.0",
+				"ses": "^1.15.0",
+				"stream-chain": "2.2.5",
+				"stream-json": "1.9.1",
+				"structon": "^1.0.7",
+				"systeminformation": "^5.31.4",
+				"tar-fs": "^3.1.2",
+				"ulidx": "0.5.0",
+				"uuid": "11.1.1",
+				"validate.js": "0.13.1",
+				"ws": "8.21.0",
+				"yaml": "2.9.0"
+			},
+			"bin": {
+				"harper": "dist/bin/harper.js"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.0.0"
+			},
+			"optionalDependencies": {
+				"bufferutil": "^4.0.9",
+				"segfault-handler": "^1.3.0",
+				"utf-8-validate": "^5.0.10"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-bedrock-runtime": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@aws-sdk/client-bedrock-runtime": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/harper/node_modules/@agoric/babel-generator": {
+			"version": "7.17.6",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.17.0",
+				"jsesc": "^2.5.1",
+				"source-map": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/harper/node_modules/@agoric/babel-generator/node_modules/source-map": {
+			"version": "0.5.7",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-crypto/crc32c": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+			"integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-crypto/sha1-browser": {
+			"version": "5.2.0",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/checksums": {
+			"version": "3.1000.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.8.tgz",
+			"integrity": "sha512-v0U9S7gBIme3OTgt1LdbAF4RpvavCc+4GK1+1xqAcqtbrHsEhjQo6R45LKcjhs/+WrRJij1Y0Gztw7QPAIeUfA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@aws-crypto/crc32c": "5.2.0",
+				"@aws-crypto/util": "5.2.0",
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/client-s3": {
+			"version": "3.1075.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1075.0.tgz",
+			"integrity": "sha512-h1A6nIl1YX6Y45enGsTK7ef3ZrOnBiQJ1qF5R2K/nMWfsu6A9mc2Y5T66nxerABzyjjyyvign3MrzafnFoQKmA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha1-browser": "5.2.0",
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/credential-provider-node": "^3.972.58",
+				"@aws-sdk/middleware-flexible-checksums": "^3.974.33",
+				"@aws-sdk/middleware-sdk-s3": "^3.972.54",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.35",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/node-http-handler": "^4.7.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/core": {
+			"version": "3.974.23",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
+			"integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.13",
+				"@aws-sdk/xml-builder": "^3.972.31",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/core": "^3.24.6",
+				"@smithy/signature-v4": "^5.4.6",
+				"@smithy/types": "^4.14.3",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.49",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.49.tgz",
+			"integrity": "sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.51",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.51.tgz",
+			"integrity": "sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/node-http-handler": "^4.7.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.972.56",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.56.tgz",
+			"integrity": "sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/credential-provider-env": "^3.972.49",
+				"@aws-sdk/credential-provider-http": "^3.972.51",
+				"@aws-sdk/credential-provider-login": "^3.972.55",
+				"@aws-sdk/credential-provider-process": "^3.972.49",
+				"@aws-sdk/credential-provider-sso": "^3.972.55",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.55",
+				"@aws-sdk/nested-clients": "^3.997.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/credential-provider-imds": "^4.3.7",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.55",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.55.tgz",
+			"integrity": "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/nested-clients": "^3.997.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.58",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.58.tgz",
+			"integrity": "sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.49",
+				"@aws-sdk/credential-provider-http": "^3.972.51",
+				"@aws-sdk/credential-provider-ini": "^3.972.56",
+				"@aws-sdk/credential-provider-process": "^3.972.49",
+				"@aws-sdk/credential-provider-sso": "^3.972.55",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.55",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/credential-provider-imds": "^4.3.7",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.49",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.49.tgz",
+			"integrity": "sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.972.55",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.55.tgz",
+			"integrity": "sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/nested-clients": "^3.997.23",
+				"@aws-sdk/token-providers": "3.1074.0",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.55",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.55.tgz",
+			"integrity": "sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/nested-clients": "^3.997.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/lib-storage": {
+			"version": "3.1075.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1075.0.tgz",
+			"integrity": "sha512-Npdac3/Fv994iCdFFeqloPel+95Zv6dRiRUpfey6W/CqpB/QdnYP60U4YBhBgJj6V5020Pm3ad0HV4WzCE5hHQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
+				"buffer": "5.6.0",
+				"events": "3.3.0",
+				"stream-browserify": "3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-s3": "^3.1075.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/middleware-flexible-checksums": {
+			"version": "3.974.33",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.33.tgz",
+			"integrity": "sha512-qMgQSPemQq2/eW/e/0+SpY4kYR5L7dUgBiVdEc5bd+ztHNv07ZMYiI+sTiir3TgKndFfglSw/VFi7oZJ6bZ63g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/checksums": "^3.1000.8",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/middleware-sdk-s3": {
+			"version": "3.972.54",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.54.tgz",
+			"integrity": "sha512-GDfDQ0gwLFRKN9gWIKcmVrHJ3e7XagnY7N1LLzMVNgnOnuY7f/ALgmy3CuBjosWD95T/Z6e+gs1IeWmLPkyLKQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.35",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/nested-clients": {
+			"version": "3.997.23",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
+			"integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.35",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/node-http-handler": "^4.7.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.996.35",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+			"integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/signature-v4": "^5.4.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1074.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1074.0.tgz",
+			"integrity": "sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.23",
+				"@aws-sdk/nested-clients": "^3.997.23",
+				"@aws-sdk/types": "^3.973.13",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/types": {
+			"version": "3.973.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+			"integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.5",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.31",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
+			"integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@aws/lambda-invoke-store": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/code-frame": {
+			"version": "7.29.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/compat-data": {
+			"version": "7.29.3",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+			"integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/core": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-module-transforms": "^7.28.6",
+				"@babel/helpers": "^7.28.6",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@jridgewell/remapping": "^2.3.5",
+				"convert-source-map": "^2.0.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/core/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/generator": {
+			"version": "7.29.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/generator/node_modules/jsesc": {
+			"version": "3.1.0",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jsesc": "bin/jsesc"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/helper-compilation-targets": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/compat-data": "^7.28.6",
+				"@babel/helper-validator-option": "^7.27.1",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^5.1.1",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/helper-globals": {
+			"version": "7.28.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/helper-module-imports": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/traverse": "^7.28.6",
+				"@babel/types": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/helper-module-transforms": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-module-imports": "^7.28.6",
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/traverse": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/helper-plugin-utils": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+			"integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/helper-string-parser": {
+			"version": "7.27.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/helper-validator-identifier": {
+			"version": "7.28.5",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/helper-validator-option": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/helpers": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.29.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/parser": {
+			"version": "7.29.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.29.0"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/plugin-syntax-async-generators": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/plugin-syntax-bigint": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+			"integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/plugin-syntax-class-properties": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+			"integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.12.13"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/plugin-syntax-class-static-block": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+			"integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/plugin-syntax-import-attributes": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+			"integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/plugin-syntax-import-meta": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+			"integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/plugin-syntax-json-strings": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/plugin-syntax-numeric-separator": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/plugin-syntax-optional-chaining": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/plugin-syntax-private-property-in-object": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+			"integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/plugin-syntax-top-level-await": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+			"integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/runtime": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/template": {
+			"version": "7.28.6",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.28.6",
+				"@babel/parser": "^7.28.6",
+				"@babel/types": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/traverse": {
+			"version": "7.29.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
+				"@babel/helper-globals": "^7.28.0",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.29.0",
+				"debug": "^4.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/harper/node_modules/@babel/types": {
+			"version": "7.29.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/harper/node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
 			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.2.2.tgz",
-			"integrity": "sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng==",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.2.2.tgz",
+			"integrity": "sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/harper/node_modules/@cbor-extract/cbor-extract-darwin-x64": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.2.2.tgz",
+			"integrity": "sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/harper/node_modules/@cbor-extract/cbor-extract-linux-arm": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.2.2.tgz",
+			"integrity": "sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/harper/node_modules/@cbor-extract/cbor-extract-linux-arm64": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.2.2.tgz",
+			"integrity": "sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/harper/node_modules/@cbor-extract/cbor-extract-linux-x64": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.2.2.tgz",
+			"integrity": "sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/harper/node_modules/@cbor-extract/cbor-extract-win32-x64": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.2.2.tgz",
+			"integrity": "sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/harper/node_modules/@colors/colors": {
+			"version": "1.5.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.1.90"
+			}
+		},
+		"node_modules/harper/node_modules/@endo/cache-map": {
+			"version": "1.1.0",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/harper/node_modules/@endo/env-options": {
+			"version": "1.1.11",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/harper/node_modules/@endo/immutable-arraybuffer": {
+			"version": "1.1.2",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/harper/node_modules/@endo/static-module-record": {
+			"version": "1.1.2",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@agoric/babel-generator": "^7.17.6",
+				"@babel/parser": "^7.23.6",
+				"@babel/traverse": "^7.23.6",
+				"@babel/types": "^7.24.0",
+				"ses": "^1.5.0"
+			}
+		},
+		"node_modules/harper/node_modules/@epic-web/invariant": {
+			"version": "1.0.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/@fastify/accept-negotiator": {
+			"version": "2.0.1",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/@fastify/ajv-compiler": {
+			"version": "4.0.5",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.12.0",
+				"ajv-formats": "^3.0.1",
+				"fast-uri": "^3.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@fastify/ajv-compiler/node_modules/ajv": {
+			"version": "8.18.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/harper/node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/@fastify/autoload": {
+			"version": "6.3.1",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/@fastify/compress": {
+			"version": "8.3.1",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@fastify/accept-negotiator": "^2.0.0",
+				"fastify-plugin": "^5.0.0",
+				"mime-db": "^1.52.0",
+				"minipass": "^7.0.4",
+				"peek-stream": "^1.1.3",
+				"pump": "^3.0.0",
+				"pumpify": "^2.0.1",
+				"readable-stream": "^4.5.2"
+			}
+		},
+		"node_modules/harper/node_modules/@fastify/compress/node_modules/buffer": {
+			"version": "6.0.3",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/harper/node_modules/@fastify/compress/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@fastify/compress/node_modules/string_decoder": {
+			"version": "1.3.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/harper/node_modules/@fastify/cors": {
+			"version": "11.2.0",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"fastify-plugin": "^5.0.0",
+				"toad-cache": "^3.7.0"
+			}
+		},
+		"node_modules/harper/node_modules/@fastify/error": {
+			"version": "4.2.0",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/@fastify/fast-json-stringify-compiler": {
+			"version": "5.0.3",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"fast-json-stringify": "^6.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@fastify/forwarded": {
+			"version": "3.0.1",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/@fastify/merge-json-schemas": {
+			"version": "0.2.1",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"dequal": "^2.0.3"
+			}
+		},
+		"node_modules/harper/node_modules/@fastify/proxy-addr": {
+			"version": "5.1.0",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@fastify/forwarded": "^3.0.0",
+				"ipaddr.js": "^2.1.0"
+			}
+		},
+		"node_modules/harper/node_modules/@fastify/send": {
+			"version": "4.1.0",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@lukeed/ms": "^2.0.2",
+				"escape-html": "~1.0.3",
+				"fast-decode-uri-component": "^1.0.1",
+				"http-errors": "^2.0.0",
+				"mime": "^3"
+			}
+		},
+		"node_modules/harper/node_modules/@fastify/static": {
+			"version": "9.1.3",
+			"resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.3.tgz",
+			"integrity": "sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@fastify/accept-negotiator": "^2.0.0",
+				"@fastify/send": "^4.0.0",
+				"content-disposition": "^1.0.1",
+				"fastify-plugin": "^5.0.0",
+				"fastq": "^1.17.1",
+				"glob": "^13.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@fastify/static/node_modules/glob": {
+			"version": "13.0.6",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/harper/node_modules/@fastify/static/node_modules/lru-cache": {
+			"version": "11.2.7",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/harper/node_modules/@fastify/static/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/harper/node_modules/@hapi/hoek": {
+			"version": "9.3.0",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/harper/node_modules/@hapi/topo": {
+			"version": "5.1.0",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@hapi/hoek": "^9.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@harperfast/extended-iterable": {
+			"version": "1.0.3",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/harper/node_modules/@harperfast/rocksdb-js": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-2.3.0.tgz",
+			"integrity": "sha512-AE0bIDjRALeqHepzrNN97ZVCCoxi2L63sYWKoD3ZHB4tAmmudguutyIH22XLjUZBSYbizA+8aNye2xcH3FOn0Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@harperfast/extended-iterable": "1.0.3",
+				"msgpackr": "2.0.4",
+				"ordered-binary": "1.6.1"
+			},
+			"bin": {
+				"rocksdb-js": "bin/rocksdb-js.mjs"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.0.0"
+			},
+			"optionalDependencies": {
+				"@harperfast/rocksdb-js-darwin-arm64": "2.3.0",
+				"@harperfast/rocksdb-js-darwin-x64": "2.3.0",
+				"@harperfast/rocksdb-js-linux-arm64-glibc": "2.3.0",
+				"@harperfast/rocksdb-js-linux-arm64-musl": "2.3.0",
+				"@harperfast/rocksdb-js-linux-x64-glibc": "2.3.0",
+				"@harperfast/rocksdb-js-linux-x64-musl": "2.3.0",
+				"@harperfast/rocksdb-js-win32-arm64": "2.3.0",
+				"@harperfast/rocksdb-js-win32-x64": "2.3.0"
+			}
+		},
+		"node_modules/harper/node_modules/@harperfast/rocksdb-js-darwin-arm64": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-2.3.0.tgz",
+			"integrity": "sha512-FuC1sF/b5QspuT/Up/j8UR3pQeaotSYeXaWaiTLr+KxvNHabifMcWP6jvNCIq2TAPV7zxkfSdpOodJ9HhJDcRA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^22.18.0 || >=24.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@harperfast/rocksdb-js-darwin-x64": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-2.3.0.tgz",
+			"integrity": "sha512-r/G7XiJkEKwKzYxjneAqq2YXf9oLMEyQB4VzrMKGCrF5z180LOfZZmK6ZbnEq5Tf9tostY8nc7colxX0/FmLrQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^22.18.0 || >=24.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@harperfast/rocksdb-js-linux-arm64-glibc": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-2.3.0.tgz",
+			"integrity": "sha512-g6vAcymhlMVQKptVOyhTTYeJfIUwyogFQXbA9ESshgaAe4BhKwdpfnty+LowXo0hSJoZChsw3HX8/5w/9pzVaA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^22.18.0 || >=24.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@harperfast/rocksdb-js-linux-arm64-musl": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-2.3.0.tgz",
+			"integrity": "sha512-L/oG5TTM3RAzxZWNB0xY02S8ByYnGnwhzrQGMCycaKDqBnEyWsvMcOLESoitjBpiMdwG7lEyeW9QPO/LW1lAXQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^22.18.0 || >=24.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@harperfast/rocksdb-js-linux-x64-glibc": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-2.3.0.tgz",
+			"integrity": "sha512-PCLG+pFyBG0dbeagsCwdfH36E4VUag8PiOjglrIZcwqIXyNbxKQqpnNpJ9EqrejcrRxvGp1Dwec0YzPzuFOBLw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^22.18.0 || >=24.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@harperfast/rocksdb-js-linux-x64-musl": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-2.3.0.tgz",
+			"integrity": "sha512-Qcx5Hs5S3hkaAuxmZ17Nb6vEN6Wjzlk2IpaBZ5m56ks71JMTnqChygX/RhGwpl3GiVFLD2QCnhb8beLbaBCV+A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^22.18.0 || >=24.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@harperfast/rocksdb-js-win32-arm64": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-2.3.0.tgz",
+			"integrity": "sha512-bPhhGAUFXVT0rlg+Aqyw9iN9FQL7M8rDLDsA1A2LhLp2PKgLwF3X665UYF9KPEUjqCljgA48tYKIsQZdfazS1w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^22.18.0 || >=24.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@harperfast/rocksdb-js-win32-x64": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-2.3.0.tgz",
+			"integrity": "sha512-oKwLf9YToA3Asa1f6YJ1FoEmY36x5ku0cHMqk2WJicy1+6HutpfexZiK60Sj2PwULgBiIowj+Kv+KxscYWuRLg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^22.18.0 || >=24.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@inquirer/external-editor": {
+			"version": "1.0.3",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chardet": "^2.1.1",
+				"iconv-lite": "^0.7.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/harper/node_modules/@isaacs/ttlcache": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
+			"integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/harper/node_modules/@istanbuljs/load-nyc-config": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"camelcase": "^5.3.1",
+				"find-up": "^4.1.0",
+				"get-package-type": "^0.1.0",
+				"js-yaml": "^3.13.1",
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/harper/node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/harper/node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/harper/node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/harper/node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/@istanbuljs/schema": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+			"integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/@jest/create-cache-key-function": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
+			"integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jest/types": "^29.6.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@jest/environment": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"jest-mock": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@jest/fake-timers": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@sinonjs/fake-timers": "^10.0.2",
+				"@types/node": "*",
+				"jest-message-util": "^29.7.0",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@jest/fake-timers/node_modules/@sinonjs/fake-timers": {
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+			"integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@jest/schemas": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@sinclair/typebox": "^0.27.8"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@jest/transform": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+			"integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/core": "^7.11.6",
+				"@jest/types": "^29.6.3",
+				"@jridgewell/trace-mapping": "^0.3.18",
+				"babel-plugin-istanbul": "^6.1.1",
+				"chalk": "^4.0.0",
+				"convert-source-map": "^2.0.0",
+				"fast-json-stable-stringify": "^2.1.0",
+				"graceful-fs": "^4.2.9",
+				"jest-haste-map": "^29.7.0",
+				"jest-regex-util": "^29.6.3",
+				"jest-util": "^29.7.0",
+				"micromatch": "^4.0.4",
+				"pirates": "^4.0.4",
+				"slash": "^3.0.0",
+				"write-file-atomic": "^4.0.2"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@jest/types": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jest/schemas": "^29.6.3",
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^3.0.0",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.8",
+				"chalk": "^4.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.13",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/harper/node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/harper/node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@jridgewell/source-map": {
+			"version": "0.3.11",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+			"integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25"
+			}
+		},
+		"node_modules/harper/node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.31",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/harper/node_modules/@lmdb/lmdb-darwin-arm64": {
+			"version": "3.5.6",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.5.6.tgz",
+			"integrity": "sha512-mY5FG4TjPAkY4P0w+OhHaUka5mDh2TX2WKYIwuKzJ1zeW3VvRgxdam/lGJTquI+bthTx5CSHDW+BAQCnNAzkEA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/harper/node_modules/@lmdb/lmdb-darwin-x64": {
+			"version": "3.5.6",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-3.5.6.tgz",
+			"integrity": "sha512-foa+pwitysO8k+xhs7psBFfTKnVgR69NlZRRTHaFVDqphh7AdGpLeyRzKw/ofatr/sN6TiHRRW6mmop0ZrrppQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/harper/node_modules/@lmdb/lmdb-linux-arm": {
+			"version": "3.5.6",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-3.5.6.tgz",
+			"integrity": "sha512-QR4YRyR5h5Z8eGXrNQjiyo2NNDfqi3tCc9dQG5Is1blCt+qWw1ZoBWhlWAr5d+jshkifMIJjVHzHGKbkKzF8Tw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/harper/node_modules/@lmdb/lmdb-linux-arm64": {
+			"version": "3.5.6",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-3.5.6.tgz",
+			"integrity": "sha512-HmiyFFdJa38s1heCMSooSPaBSFTHJ3C+ERPp28xAPlDX1YiALJVOgbry065nXd8Y7KISWjnw05zpG1RX8IfftA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/harper/node_modules/@lmdb/lmdb-linux-x64": {
+			"version": "3.5.6",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-3.5.6.tgz",
+			"integrity": "sha512-ADzCuCF2cTNiX9kDScqcz1fjnAkxPpQNneV3KFTdV3wWtVlI2sTGzySoMTgDpinkMMFj1NTJlxA6XR8fwc4hlA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/harper/node_modules/@lmdb/lmdb-win32-arm64": {
+			"version": "3.5.6",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-arm64/-/lmdb-win32-arm64-3.5.6.tgz",
+			"integrity": "sha512-J7A9aEQsQiv0TYtBGL7NDIPp2lOS8nnl+zm4sWZm1xlsTTaQ4PgD096Adzdrk27rw3UxCkDXdCUa4ax41oztBQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/harper/node_modules/@lmdb/lmdb-win32-x64": {
+			"version": "3.5.6",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.5.6.tgz",
+			"integrity": "sha512-1g7G0knRX2iV/voDu54yxrGqw5Dk0w2oIYb7dgJq8IkOi+m7wbD8Q3QpPFjh0C01G58S88dqGn03len6UPCXsg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/harper/node_modules/@lukeed/ms": {
+			"version": "2.0.2",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+			"integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/harper/node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+			"integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/harper/node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+			"integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/harper/node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+			"integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/harper/node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+			"integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/harper/node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+			"integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/harper/node_modules/@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/harper/node_modules/@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/harper/node_modules/@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/harper/node_modules/@phc/format": {
+			"version": "1.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/harper/node_modules/@pinojs/redact": {
+			"version": "0.4.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/@react-native/assets-registry": {
+			"version": "0.82.1",
+			"resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.82.1.tgz",
+			"integrity": "sha512-B1SRwpntaAcckiatxbjzylvNK562Ayza05gdJCjDQHTiDafa1OABmyB5LHt7qWDOpNkaluD+w11vHF7pBmTpzQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/@react-native/codegen": {
+			"version": "0.82.1",
+			"resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.82.1.tgz",
+			"integrity": "sha512-ezXTN70ygVm9l2m0i+pAlct0RntoV4afftWMGUIeAWLgaca9qItQ54uOt32I/9dBJvzBibT33luIR/pBG0dQvg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/core": "^7.25.2",
+				"@babel/parser": "^7.25.3",
+				"glob": "^7.1.1",
+				"hermes-parser": "0.32.0",
+				"invariant": "^2.2.4",
+				"nullthrows": "^1.1.1",
+				"yargs": "^17.6.2"
+			},
+			"engines": {
+				"node": ">= 20.19.4"
+			},
+			"peerDependencies": {
+				"@babel/core": "*"
+			}
+		},
+		"node_modules/harper/node_modules/@react-native/codegen/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/@react-native/codegen/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/harper/node_modules/@react-native/codegen/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/harper/node_modules/@react-native/codegen/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/harper/node_modules/@react-native/codegen/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/harper/node_modules/@react-native/codegen/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/harper/node_modules/@react-native/codegen/node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/harper/node_modules/@react-native/community-cli-plugin": {
+			"version": "0.82.1",
+			"resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.82.1.tgz",
+			"integrity": "sha512-H/eMdtOy9nEeX7YVeEG1N2vyCoifw3dr9OV8++xfUElNYV7LtSmJ6AqxZUUfxGJRDFPQvaU/8enmJlM/l11VxQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@react-native/dev-middleware": "0.82.1",
+				"debug": "^4.4.0",
+				"invariant": "^2.2.4",
+				"metro": "^0.83.1",
+				"metro-config": "^0.83.1",
+				"metro-core": "^0.83.1",
+				"semver": "^7.1.3"
+			},
+			"engines": {
+				"node": ">= 20.19.4"
+			},
+			"peerDependencies": {
+				"@react-native-community/cli": "*",
+				"@react-native/metro-config": "*"
+			},
+			"peerDependenciesMeta": {
+				"@react-native-community/cli": {
+					"optional": true
+				},
+				"@react-native/metro-config": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/harper/node_modules/@react-native/debugger-frontend": {
+			"version": "0.82.1",
+			"resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.82.1.tgz",
+			"integrity": "sha512-a2O6M7/OZ2V9rdavOHyCQ+10z54JX8+B+apYKCQ6a9zoEChGTxUMG2YzzJ8zZJVvYf1ByWSNxv9Se0dca1hO9A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/@react-native/debugger-shell": {
+			"version": "0.82.1",
+			"resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.82.1.tgz",
+			"integrity": "sha512-fdRHAeqqPT93bSrxfX+JHPpCXHApfDUdrXMXhoxlPgSzgXQXJDykIViKhtpu0M6slX6xU/+duq+AtP/qWJRpBw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"fb-dotslash": "0.5.8"
+			},
+			"engines": {
+				"node": ">= 20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/@react-native/dev-middleware": {
+			"version": "0.82.1",
+			"resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.82.1.tgz",
+			"integrity": "sha512-wuOIzms/Qg5raBV6Ctf2LmgzEOCqdP3p1AYN4zdhMT110c39TVMbunpBaJxm0Kbt2HQ762MQViF9naxk7SBo4w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@isaacs/ttlcache": "^1.4.1",
+				"@react-native/debugger-frontend": "0.82.1",
+				"@react-native/debugger-shell": "0.82.1",
+				"chrome-launcher": "^0.15.2",
+				"chromium-edge-launcher": "^0.2.0",
+				"connect": "^3.6.5",
+				"debug": "^4.4.0",
+				"invariant": "^2.2.4",
+				"nullthrows": "^1.1.1",
+				"open": "^7.0.3",
+				"serve-static": "^1.16.2",
+				"ws": "^6.2.3"
+			},
+			"engines": {
+				"node": ">= 20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/@react-native/dev-middleware/node_modules/ws": {
+			"version": "6.2.4",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.4.tgz",
+			"integrity": "sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"async-limiter": "~1.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@react-native/gradle-plugin": {
+			"version": "0.82.1",
+			"resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.82.1.tgz",
+			"integrity": "sha512-KkF/2T1NSn6EJ5ALNT/gx0MHlrntFHv8YdooH9OOGl9HQn5NM0ZmQSr86o5utJsGc7ME3R6p3SaQuzlsFDrn8Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/@react-native/js-polyfills": {
+			"version": "0.82.1",
+			"resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.82.1.tgz",
+			"integrity": "sha512-tf70X7pUodslOBdLN37J57JmDPB/yiZcNDzS2m+4bbQzo8fhx3eG9QEBv5n4fmzqfGAgSB4BWRHgDMXmmlDSVA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/@react-native/normalize-colors": {
+			"version": "0.82.1",
+			"resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.82.1.tgz",
+			"integrity": "sha512-CCfTR1uX+Z7zJTdt3DNX9LUXr2zWXsNOyLbwupW2wmRzrxlHRYfmLgTABzRL/cKhh0Ubuwn15o72MQChvCRaHw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/@react-native/virtualized-lists": {
+			"version": "0.82.1",
+			"resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.82.1.tgz",
+			"integrity": "sha512-f5zpJg9gzh7JtCbsIwV+4kP3eI0QBuA93JGmwFRd4onQ3DnCjV2J5pYqdWtM95sjSKK1dyik59Gj01lLeKqs1Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"invariant": "^2.2.4",
+				"nullthrows": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 20.19.4"
+			},
+			"peerDependencies": {
+				"@types/react": "^19.1.1",
+				"react": "*",
+				"react-native": "*"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/harper/node_modules/@sideway/address": {
+			"version": "4.1.5",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@hapi/hoek": "^9.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@sideway/formula": {
+			"version": "3.0.1",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/harper/node_modules/@sideway/pinpoint": {
+			"version": "2.0.0",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/harper/node_modules/@sinclair/typebox": {
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+			"integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/@sinonjs/commons": {
+			"version": "3.0.1",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"node_modules/harper/node_modules/@smithy/core": {
+			"version": "3.26.0",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
+			"integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.15.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@smithy/credential-provider-imds": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
+			"integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.26.0",
+				"@smithy/types": "^4.15.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@smithy/fetch-http-handler": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.2.tgz",
+			"integrity": "sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.26.0",
+				"@smithy/types": "^4.15.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@smithy/node-http-handler": {
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
+			"integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.26.0",
+				"@smithy/types": "^4.15.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@smithy/signature-v4": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
+			"integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.26.0",
+				"@smithy/types": "^4.15.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@smithy/types": {
+			"version": "4.15.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+			"integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/area": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/meta": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/bbox": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/meta": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/boolean-contains": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/bbox": "^6.5.0",
+				"@turf/boolean-point-in-polygon": "^6.5.0",
+				"@turf/boolean-point-on-line": "^6.5.0",
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/boolean-disjoint": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/boolean-point-in-polygon": "^6.5.0",
+				"@turf/helpers": "^6.5.0",
+				"@turf/line-intersect": "^6.5.0",
+				"@turf/meta": "^6.5.0",
+				"@turf/polygon-to-line": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/boolean-equal": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/clean-coords": "^6.5.0",
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0",
+				"geojson-equality": "0.1.6"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/boolean-point-in-polygon": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/boolean-point-on-line": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/circle": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/destination": "^6.5.0",
+				"@turf/helpers": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/clean-coords": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/destination": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/difference": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0",
+				"polygon-clipping": "^0.15.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/distance": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/helpers": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/invariant": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/length": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/distance": "^6.5.0",
+				"@turf/helpers": "^6.5.0",
+				"@turf/meta": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/line-intersect": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0",
+				"@turf/line-segment": "^6.5.0",
+				"@turf/meta": "^6.5.0",
+				"geojson-rbush": "3.x"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/line-segment": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0",
+				"@turf/meta": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/meta": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@turf/polygon-to-line": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/harper/node_modules/@types/babel__core": {
+			"version": "7.20.5",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/parser": "^7.20.7",
+				"@babel/types": "^7.20.7",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"node_modules/harper/node_modules/@types/babel__generator": {
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+			"integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@types/babel__template": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/@types/babel__traverse": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+			"integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/types": "^7.28.2"
+			}
+		},
+		"node_modules/harper/node_modules/@types/geojson": {
+			"version": "7946.0.8",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/@types/graceful-fs": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+			"integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/harper/node_modules/@types/istanbul-lib-coverage": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/@types/istanbul-lib-report": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+			"integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"node_modules/harper/node_modules/@types/istanbul-reports": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+			"integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/istanbul-lib-report": "*"
+			}
+		},
+		"node_modules/harper/node_modules/@types/node": {
+			"version": "25.4.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.18.0"
+			}
+		},
+		"node_modules/harper/node_modules/@types/readable-stream": {
+			"version": "4.0.23",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/harper/node_modules/@types/stack-utils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/@types/yargs": {
+			"version": "17.0.35",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+			"integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"node_modules/harper/node_modules/@types/yargs-parser": {
+			"version": "21.0.3",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/abort-controller": {
+			"version": "3.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"event-target-shim": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6.5"
+			}
+		},
+		"node_modules/harper/node_modules/abstract-logging": {
+			"version": "2.0.1",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/accepts": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/harper/node_modules/accepts/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/harper/node_modules/acorn": {
+			"version": "8.16.0",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/harper/node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/harper/node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/harper/node_modules/ajv-formats/node_modules/ajv": {
+			"version": "8.18.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/harper/node_modules/ajv-formats/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/alasql": {
+			"version": "4.17.3",
+			"resolved": "https://registry.npmjs.org/alasql/-/alasql-4.17.3.tgz",
+			"integrity": "sha512-EOBD6zfZJ1u6Y76672MapJOyahzjDIQGE7nspt4yKhBWZB2k0cIHHakx6iJaolKkjB4vMPIo09ysw52aQfZ9rw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cross-fetch": "4.1.0",
+				"yargs": "16"
+			},
+			"bin": {
+				"alasql": "bin/alasql-cli.js"
+			},
+			"engines": {
+				"node": ">=15"
+			},
+			"optionalDependencies": {
+				"react-native-fs": "^2.20.0"
+			}
+		},
+		"node_modules/harper/node_modules/amaro": {
+			"version": "1.1.10",
+			"resolved": "https://registry.npmjs.org/amaro/-/amaro-1.1.10.tgz",
+			"integrity": "sha512-ceFv+QA3SlhFsn0hu8Q8oyj36YZdIgoJFpyS2sGJGK2dyncwcMWuBlNzhXfc1oLWtbDWM2Ol2rrzOYa+HNyEjg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22"
+			}
+		},
+		"node_modules/harper/node_modules/anser": {
+			"version": "1.4.10",
+			"resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
+			"integrity": "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/ansi-escapes": {
+			"version": "4.3.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^0.21.3"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/harper/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/harper/node_modules/anymatch": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/harper/node_modules/argon2": {
+			"version": "0.44.0",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"@phc/format": "^1.0.0",
+				"cross-env": "^10.0.0",
+				"node-addon-api": "^8.5.0",
+				"node-gyp-build": "^4.8.4"
+			},
+			"engines": {
+				"node": ">=16.17.0"
+			}
+		},
+		"node_modules/harper/node_modules/argon2/node_modules/node-gyp-build": {
+			"version": "4.8.4",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
+			}
+		},
+		"node_modules/harper/node_modules/asap": {
+			"version": "2.0.6",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/asn1js": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+			"integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"pvtsutils": "^1.3.6",
+				"pvutils": "^1.1.5",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/async": {
+			"version": "3.2.3",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/async-limiter": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/atomic-sleep": {
+			"version": "1.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/avvio": {
+			"version": "9.2.0",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@fastify/error": "^4.0.0",
+				"fastq": "^1.17.1"
+			}
+		},
+		"node_modules/harper/node_modules/b4a": {
+			"version": "1.8.0",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/harper/node_modules/babel-jest": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+			"integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jest/transform": "^29.7.0",
+				"@types/babel__core": "^7.1.14",
+				"babel-plugin-istanbul": "^6.1.1",
+				"babel-preset-jest": "^29.6.3",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.8.0"
+			}
+		},
+		"node_modules/harper/node_modules/babel-plugin-istanbul": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+			"integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@istanbuljs/load-nyc-config": "^1.0.0",
+				"@istanbuljs/schema": "^0.1.2",
+				"istanbul-lib-instrument": "^5.0.4",
+				"test-exclude": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/babel-plugin-jest-hoist": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+			"integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/template": "^7.3.3",
+				"@babel/types": "^7.3.3",
+				"@types/babel__core": "^7.1.14",
+				"@types/babel__traverse": "^7.0.6"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/babel-plugin-syntax-hermes-parser": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.0.tgz",
+			"integrity": "sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"hermes-parser": "0.32.0"
+			}
+		},
+		"node_modules/harper/node_modules/babel-preset-current-node-syntax": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+			"integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/plugin-syntax-async-generators": "^7.8.4",
+				"@babel/plugin-syntax-bigint": "^7.8.3",
+				"@babel/plugin-syntax-class-properties": "^7.12.13",
+				"@babel/plugin-syntax-class-static-block": "^7.14.5",
+				"@babel/plugin-syntax-import-attributes": "^7.24.7",
+				"@babel/plugin-syntax-import-meta": "^7.10.4",
+				"@babel/plugin-syntax-json-strings": "^7.8.3",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
+				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+				"@babel/plugin-syntax-top-level-await": "^7.14.5"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0 || ^8.0.0-0"
+			}
+		},
+		"node_modules/harper/node_modules/babel-preset-jest": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+			"integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"babel-plugin-jest-hoist": "^29.6.3",
+				"babel-preset-current-node-syntax": "^1.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/harper/node_modules/bare-events": {
+			"version": "2.8.2",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"bare-abort-controller": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/harper/node_modules/bare-fs": {
+			"version": "4.5.5",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-events": "^2.5.4",
+				"bare-path": "^3.0.0",
+				"bare-stream": "^2.6.4",
+				"bare-url": "^2.2.2",
+				"fast-fifo": "^1.3.2"
+			},
+			"engines": {
+				"bare": ">=1.16.0"
+			},
+			"peerDependencies": {
+				"bare-buffer": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-buffer": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/harper/node_modules/bare-os": {
+			"version": "3.7.1",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"bare": ">=1.14.0"
+			}
+		},
+		"node_modules/harper/node_modules/bare-path": {
+			"version": "3.0.0",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-os": "^3.0.1"
+			}
+		},
+		"node_modules/harper/node_modules/bare-stream": {
+			"version": "2.8.1",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"streamx": "^2.21.0",
+				"teex": "^1.0.1"
+			},
+			"peerDependencies": {
+				"bare-buffer": "*",
+				"bare-events": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-buffer": {
+					"optional": true
+				},
+				"bare-events": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/harper/node_modules/bare-url": {
+			"version": "2.3.2",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-path": "^3.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/base-64": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+			"integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==",
+			"dev": true,
+			"optional": true
+		},
+		"node_modules/harper/node_modules/base64-js": {
+			"version": "1.5.1",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/baseline-browser-mapping": {
+			"version": "2.10.32",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+			"integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/harper/node_modules/bindings": {
+			"version": "1.5.0",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/bl": {
+			"version": "6.1.6",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/readable-stream": "^4.0.0",
+				"buffer": "^6.0.3",
+				"inherits": "^2.0.4",
+				"readable-stream": "^4.2.0"
+			}
+		},
+		"node_modules/harper/node_modules/bl/node_modules/buffer": {
+			"version": "6.0.3",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/harper/node_modules/bl/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/bl/node_modules/string_decoder": {
+			"version": "1.3.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/harper/node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/brace-expansion": {
+			"version": "5.0.4",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/harper/node_modules/braces": {
+			"version": "3.0.3",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fill-range": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/browserify-zlib": {
+			"version": "0.1.4",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pako": "~0.2.0"
+			}
+		},
+		"node_modules/harper/node_modules/browserslist": {
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
+			},
+			"bin": {
+				"browserslist": "cli.js"
+			},
+			"engines": {
+				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			}
+		},
+		"node_modules/harper/node_modules/bser": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"node-int64": "^0.4.0"
+			}
+		},
+		"node_modules/harper/node_modules/buffer": {
+			"version": "5.6.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4"
+			}
+		},
+		"node_modules/harper/node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/harper/node_modules/buffer-from": {
+			"version": "1.1.2",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/bufferutil": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+			"integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"node-gyp-build": "^4.3.0"
+			},
+			"engines": {
+				"node": ">=6.14.2"
+			}
+		},
+		"node_modules/harper/node_modules/bufferutil/node_modules/node-gyp-build": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
+			}
+		},
+		"node_modules/harper/node_modules/busboy": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+			"dev": true,
+			"dependencies": {
+				"streamsearch": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=10.16.0"
+			}
+		},
+		"node_modules/harper/node_modules/bytestreamjs": {
+			"version": "2.0.1",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/call-bind": {
+			"version": "1.0.8",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.0",
+				"es-define-property": "^1.0.0",
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/harper/node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/harper/node_modules/call-bound": {
+			"version": "1.0.4",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/harper/node_modules/camelcase": {
+			"version": "6.3.0",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/harper/node_modules/caniuse-lite": {
+			"version": "1.0.30001793",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+			"integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "CC-BY-4.0",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/cbor-extract": {
+			"version": "2.2.2",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -4478,20 +5135,16 @@
 				"@cbor-extract/cbor-extract-win32-x64": "2.2.2"
 			}
 		},
-		"node_modules/cbor-x": {
+		"node_modules/harper/node_modules/cbor-x": {
 			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.6.4.tgz",
-			"integrity": "sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q==",
 			"dev": true,
 			"license": "MIT",
 			"optionalDependencies": {
 				"cbor-extract": "^2.2.2"
 			}
 		},
-		"node_modules/chalk": {
+		"node_modules/harper/node_modules/chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4505,17 +5158,13 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"node_modules/chardet": {
+		"node_modules/harper/node_modules/chardet": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-			"integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/chokidar": {
+		"node_modules/harper/node_modules/chokidar": {
 			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4528,10 +5177,64 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
-		"node_modules/cli-cursor": {
+		"node_modules/harper/node_modules/chrome-launcher": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
+			"integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*",
+				"escape-string-regexp": "^4.0.0",
+				"is-wsl": "^2.2.0",
+				"lighthouse-logger": "^1.0.0"
+			},
+			"bin": {
+				"print-chrome-path": "bin/print-chrome-path.js"
+			},
+			"engines": {
+				"node": ">=12.13.0"
+			}
+		},
+		"node_modules/harper/node_modules/chromium-edge-launcher": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.2.0.tgz",
+			"integrity": "sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*",
+				"escape-string-regexp": "^4.0.0",
+				"is-wsl": "^2.2.0",
+				"lighthouse-logger": "^1.0.0",
+				"mkdirp": "^1.0.4",
+				"rimraf": "^3.0.2"
+			}
+		},
+		"node_modules/harper/node_modules/ci-info": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/cli-cursor": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4541,10 +5244,8 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/cli-progress": {
+		"node_modules/harper/node_modules/cli-progress": {
 			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
-			"integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4554,10 +5255,8 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/cli-spinners": {
+		"node_modules/harper/node_modules/cli-spinners": {
 			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-			"integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4567,26 +5266,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/cli-width": {
+		"node_modules/harper/node_modules/cli-width": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-			"integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">= 10"
 			}
 		},
-		"node_modules/client-only": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-			"integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
-			"license": "MIT"
-		},
-		"node_modules/cliui": {
+		"node_modules/harper/node_modules/cliui": {
 			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -4595,10 +5284,8 @@
 				"wrap-ansi": "^7.0.0"
 			}
 		},
-		"node_modules/cliui/node_modules/wrap-ansi": {
+		"node_modules/harper/node_modules/cliui/node_modules/wrap-ansi": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4613,20 +5300,16 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"node_modules/clone": {
+		"node_modules/harper/node_modules/clone": {
 			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8"
 			}
 		},
-		"node_modules/color-convert": {
+		"node_modules/harper/node_modules/color-convert": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4636,27 +5319,33 @@
 				"node": ">=7.0.0"
 			}
 		},
-		"node_modules/color-name": {
+		"node_modules/harper/node_modules/color-name": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/colors": {
+		"node_modules/harper/node_modules/colors": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-			"integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.1.90"
 			}
 		},
-		"node_modules/complex.js": {
+		"node_modules/harper/node_modules/commander": {
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/harper/node_modules/complex.js": {
 			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.4.3.tgz",
-			"integrity": "sha512-UrQVSUur14tNX6tiP4y8T4w4FeJAX3bi2cIv0pu/DTLFNxoq7z2Yh83Vfzztj6Px3X/lubqQ9IrPp7Bpn6p4MQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4667,10 +5356,54 @@
 				"url": "https://github.com/sponsors/rawify"
 			}
 		},
-		"node_modules/content-disposition": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
-			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+		"node_modules/harper/node_modules/concat-map": {
+			"version": "0.0.1",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/connect": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+			"integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"debug": "2.6.9",
+				"finalhandler": "1.1.2",
+				"parseurl": "~1.3.3",
+				"utils-merge": "1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			}
+		},
+		"node_modules/harper/node_modules/connect/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/connect/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/content-disposition": {
+			"version": "1.0.1",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4681,10 +5414,17 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/cookie": {
+		"node_modules/harper/node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/cookie": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-			"integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4695,17 +5435,13 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/core-util-is": {
+		"node_modules/harper/node_modules/core-util-is": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/cross-env": {
+		"node_modules/harper/node_modules/cross-env": {
 			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
-			"integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4720,20 +5456,16 @@
 				"node": ">=20"
 			}
 		},
-		"node_modules/cross-fetch": {
+		"node_modules/harper/node_modules/cross-fetch": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
-			"integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"node-fetch": "^2.7.0"
 			}
 		},
-		"node_modules/cross-spawn": {
+		"node_modules/harper/node_modules/cross-spawn": {
 			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4745,19 +5477,15 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/cycle": {
+		"node_modules/harper/node_modules/cycle": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-			"integrity": "sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/debug": {
+		"node_modules/harper/node_modules/debug": {
 			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4772,17 +5500,13 @@
 				}
 			}
 		},
-		"node_modules/decimal.js": {
+		"node_modules/harper/node_modules/decimal.js": {
 			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/deep-equal": {
+		"node_modules/harper/node_modules/deep-equal": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
-			"integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4800,10 +5524,8 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/defaults": {
+		"node_modules/harper/node_modules/defaults": {
 			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-			"integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4813,20 +5535,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/defaults/node_modules/clone": {
+		"node_modules/harper/node_modules/defaults/node_modules/clone": {
 			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8"
 			}
 		},
-		"node_modules/define-data-property": {
+		"node_modules/harper/node_modules/define-data-property": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4841,10 +5559,8 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/define-properties": {
+		"node_modules/harper/node_modules/define-properties": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4859,40 +5575,45 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/depd": {
+		"node_modules/harper/node_modules/depd": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/dequal": {
+		"node_modules/harper/node_modules/dequal": {
 			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
-		"node_modules/detect-libc": {
+		"node_modules/harper/node_modules/destroy": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+			"integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 0.8",
+				"npm": "1.2.8000 || >= 1.4.16"
+			}
+		},
+		"node_modules/harper/node_modules/detect-libc": {
 			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8"
 			}
 		},
-		"node_modules/dotenv": {
+		"node_modules/harper/node_modules/dotenv": {
 			"version": "16.6.1",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
@@ -4902,10 +5623,8 @@
 				"url": "https://dotenvx.com"
 			}
 		},
-		"node_modules/dunder-proto": {
+		"node_modules/harper/node_modules/dunder-proto": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4917,56 +5636,34 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/duplexify": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-			"integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+		"node_modules/harper/node_modules/duplexify": {
+			"version": "4.1.3",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"end-of-stream": "^1.0.0",
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.0",
-				"stream-shift": "^1.0.0"
+				"end-of-stream": "^1.4.1",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1",
+				"stream-shift": "^1.0.2"
 			}
 		},
-		"node_modules/duplexify/node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+		"node_modules/harper/node_modules/duplexify/node_modules/readable-stream": {
+			"version": "3.6.2",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
-		"node_modules/duplexify/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/duplexify/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"node_modules/easy-ocsp": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/easy-ocsp/-/easy-ocsp-1.3.1.tgz",
-			"integrity": "sha512-/xBKk3i6uqLyOPdeF+06WUkMEFtUgybr9PtOzJfACNiJqvZ8Ek3qwPW73IwkkDiXmLDWm7bAxRdkrYP6fXs/uw==",
+		"node_modules/harper/node_modules/easy-ocsp": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/easy-ocsp/-/easy-ocsp-1.3.2.tgz",
+			"integrity": "sha512-4TonRbfynC2IRMF9gqFA1bEEF41rp0oPJrPYf8YIBibc2QVbSSDmBbKL0+1U2nVrZ4siGA18SIKhm8B9jLGK+A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4977,74 +5674,79 @@
 				"node": ">=18.13.0"
 			}
 		},
-		"node_modules/ecdsa-sig-formatter": {
+		"node_modules/harper/node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"node_modules/ee-first": {
+		"node_modules/harper/node_modules/ee-first": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/emoji-regex": {
+		"node_modules/harper/node_modules/electron-to-chromium": {
+			"version": "1.5.361",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
+			"integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/emoji-regex": {
 			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/encodeurl": {
+		"node_modules/harper/node_modules/encodeurl": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/end-of-stream": {
+		"node_modules/harper/node_modules/end-of-stream": {
 			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"once": "^1.4.0"
 			}
 		},
-		"node_modules/es-define-property": {
+		"node_modules/harper/node_modules/error-stack-parser": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+			"integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"stackframe": "^1.3.4"
+			}
+		},
+		"node_modules/harper/node_modules/es-define-property": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/es-errors": {
+		"node_modules/harper/node_modules/es-errors": {
 			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/es-object-atoms": {
+		"node_modules/harper/node_modules/es-object-atoms": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5054,114 +5756,118 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/escalade": {
+		"node_modules/harper/node_modules/escalade": {
 			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
-		"node_modules/escape-html": {
+		"node_modules/harper/node_modules/escape-html": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/escape-latex": {
+		"node_modules/harper/node_modules/escape-latex": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
-			"integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+		"node_modules/harper/node_modules/escape-string-regexp": {
+			"version": "4.0.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
-				"node": ">=0.8.0"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/etag": {
+		"node_modules/harper/node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/harper/node_modules/etag": {
 			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/event-target-shim": {
+		"node_modules/harper/node_modules/event-target-shim": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
-		"node_modules/events": {
+		"node_modules/harper/node_modules/events": {
 			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.x"
 			}
 		},
-		"node_modules/events-universal": {
+		"node_modules/harper/node_modules/events-universal": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
-			"integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"bare-events": "^2.7.0"
 			}
 		},
-		"node_modules/eyes": {
+		"node_modules/harper/node_modules/exponential-backoff": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+			"integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/eyes": {
 			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-			"integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
 			"dev": true,
 			"engines": {
 				"node": "> 0.1.90"
 			}
 		},
-		"node_modules/fast-decode-uri-component": {
+		"node_modules/harper/node_modules/fast-decode-uri-component": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
-			"integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/fast-deep-equal": {
+		"node_modules/harper/node_modules/fast-deep-equal": {
 			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/fast-fifo": {
+		"node_modules/harper/node_modules/fast-fifo": {
 			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/fast-glob": {
+		"node_modules/harper/node_modules/fast-glob": {
 			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5175,10 +5881,26 @@
 				"node": ">=8.6.0"
 			}
 		},
-		"node_modules/fast-json-stringify": {
+		"node_modules/harper/node_modules/fast-glob/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/harper/node_modules/fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/fast-json-stringify": {
 			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.3.0.tgz",
-			"integrity": "sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==",
 			"dev": true,
 			"funding": [
 				{
@@ -5200,30 +5922,44 @@
 				"rfdc": "^1.2.0"
 			}
 		},
-		"node_modules/fast-querystring": {
+		"node_modules/harper/node_modules/fast-json-stringify/node_modules/ajv": {
+			"version": "8.18.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/harper/node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/fast-querystring": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
-			"integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-decode-uri-component": "^1.0.1"
 			}
 		},
-		"node_modules/fast-redact": {
+		"node_modules/harper/node_modules/fast-redact": {
 			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-			"integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
-		"node_modules/fast-uri": {
+		"node_modules/harper/node_modules/fast-uri": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
 			"dev": true,
 			"funding": [
 				{
@@ -5237,45 +5973,7 @@
 			],
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/fast-xml-builder": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-			"integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"path-expression-matcher": "^1.1.3"
-			}
-		},
-		"node_modules/fast-xml-parser": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
-			"integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@nodable/entities": "^2.1.0",
-				"fast-xml-builder": "^1.1.5",
-				"path-expression-matcher": "^1.5.0",
-				"strnum": "^2.2.3"
-			},
-			"bin": {
-				"fxparser": "src/cli/cli.js"
-			}
-		},
-		"node_modules/fastify": {
+		"node_modules/harper/node_modules/fastify": {
 			"version": "5.8.5",
 			"resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
 			"integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
@@ -5309,10 +6007,8 @@
 				"toad-cache": "^3.7.0"
 			}
 		},
-		"node_modules/fastify-plugin": {
+		"node_modules/harper/node_modules/fastify-plugin": {
 			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
-			"integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
 			"dev": true,
 			"funding": [
 				{
@@ -5326,7 +6022,7 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/fastify/node_modules/pino": {
+		"node_modules/harper/node_modules/fastify/node_modules/pino": {
 			"version": "10.3.1",
 			"resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
 			"integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
@@ -5349,24 +6045,14 @@
 				"pino": "bin.js"
 			}
 		},
-		"node_modules/fastify/node_modules/pino-abstract-transport": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
-			"integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"split2": "^4.0.0"
-			}
-		},
-		"node_modules/fastify/node_modules/pino-std-serializers": {
+		"node_modules/harper/node_modules/fastify/node_modules/pino-std-serializers": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
 			"integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/fastify/node_modules/sonic-boom": {
+		"node_modules/harper/node_modules/fastify/node_modules/sonic-boom": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
 			"integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
@@ -5376,33 +6062,63 @@
 				"atomic-sleep": "^1.0.0"
 			}
 		},
-		"node_modules/fastify/node_modules/thread-stream": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
-			"integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+		"node_modules/harper/node_modules/fastify/node_modules/thread-stream": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.1.0.tgz",
+			"integrity": "sha512-Bw6h2iBDt16v6iHLChBIoVYU8CBo9GPsW8TG7h1hRVhqKhIkH6N8qkxNSmiOZTKsCLPbtWG4ViWLkU6KeKXpig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"real-require": "^0.2.0"
+				"real-require": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=20"
 			}
 		},
-		"node_modules/fastq": {
+		"node_modules/harper/node_modules/fastify/node_modules/thread-stream/node_modules/real-require": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+			"integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/fastq": {
 			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
 			}
 		},
-		"node_modules/figures": {
+		"node_modules/harper/node_modules/fb-dotslash": {
+			"version": "0.5.8",
+			"resolved": "https://registry.npmjs.org/fb-dotslash/-/fb-dotslash-0.5.8.tgz",
+			"integrity": "sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==",
+			"dev": true,
+			"license": "(MIT OR Apache-2.0)",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"dotslash": "bin/dotslash"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/harper/node_modules/fb-watchman": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+			"integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"bser": "2.1.1"
+			}
+		},
+		"node_modules/harper/node_modules/figures": {
 			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5415,18 +6131,22 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/file-uri-to-path": {
+		"node_modules/harper/node_modules/figures/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/harper/node_modules/file-uri-to-path": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true
 		},
-		"node_modules/fill-range": {
+		"node_modules/harper/node_modules/fill-range": {
 			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5436,10 +6156,89 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/find-my-way": {
+		"node_modules/harper/node_modules/finalhandler": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"debug": "2.6.9",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.3",
+				"statuses": "~1.5.0",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/harper/node_modules/finalhandler/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/finalhandler/node_modules/encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/harper/node_modules/finalhandler/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/finalhandler/node_modules/on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/harper/node_modules/finalhandler/node_modules/statuses": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/harper/node_modules/find-my-way": {
 			"version": "9.5.0",
-			"resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.5.0.tgz",
-			"integrity": "sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5451,10 +6250,17 @@
 				"node": ">=20"
 			}
 		},
-		"node_modules/fraction.js": {
+		"node_modules/harper/node_modules/flow-enums-runtime": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz",
+			"integrity": "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/fraction.js": {
 			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.4.tgz",
-			"integrity": "sha512-pwiTgt0Q7t+GHZA4yaLjObx4vXmmdcS0iSJ19o8d/goUGgItX9UZWKWNnLHehxviD8wU2IWRsnR8cD5+yOJP2Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5465,20 +6271,18 @@
 				"url": "https://github.com/sponsors/rawify"
 			}
 		},
-		"node_modules/fresh": {
+		"node_modules/harper/node_modules/fresh": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/fs-extra": {
-			"version": "11.3.4",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-			"integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+		"node_modules/harper/node_modules/fs-extra": {
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5490,10 +6294,19 @@
 				"node": ">=14.14"
 			}
 		},
-		"node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+		"node_modules/harper/node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -5501,44 +6314,49 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
-		"node_modules/function-bind": {
+		"node_modules/harper/node_modules/function-bind": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/functions-have-names": {
+		"node_modules/harper/node_modules/functions-have-names": {
 			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/geojson-equality": {
+		"node_modules/harper/node_modules/gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/harper/node_modules/geojson-equality": {
 			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/geojson-equality/-/geojson-equality-0.1.6.tgz",
-			"integrity": "sha512-TqG8YbqizP3EfwP5Uw4aLu6pKkg6JQK9uq/XZ1lXQntvTHD1BBKJWhNpJ2M0ax6TuWMP3oyx6Oq7FCIfznrgpQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"deep-equal": "^1.0.0"
 			}
 		},
-		"node_modules/geojson-rbush": {
+		"node_modules/harper/node_modules/geojson-rbush": {
 			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-3.2.0.tgz",
-			"integrity": "sha512-oVltQTXolxvsz1sZnutlSuLDEcQAKYC/uXt9zDzJJ6bu0W+baTI8LZBaTup5afzibEH4N3jlq2p+a152wlBJ7w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5549,20 +6367,16 @@
 				"rbush": "^3.0.1"
 			}
 		},
-		"node_modules/get-caller-file": {
+		"node_modules/harper/node_modules/get-caller-file": {
 			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
-		"node_modules/get-east-asian-width": {
+		"node_modules/harper/node_modules/get-east-asian-width": {
 			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5572,10 +6386,8 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/get-intrinsic": {
+		"node_modules/harper/node_modules/get-intrinsic": {
 			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5597,10 +6409,20 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/get-proto": {
+		"node_modules/harper/node_modules/get-package-type": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/get-proto": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5611,41 +6433,8 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/glob": {
-			"version": "13.0.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"minimatch": "^10.2.2",
-				"minipass": "^7.1.3",
-				"path-scurry": "^2.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/gopd": {
+		"node_modules/harper/node_modules/gopd": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5655,27 +6444,23 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/graceful-fs": {
+		"node_modules/harper/node_modules/graceful-fs": {
 			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/graphql": {
-			"version": "16.13.2",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-			"integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+		"node_modules/harper/node_modules/graphql": {
+			"version": "16.14.2",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+			"integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
 			}
 		},
-		"node_modules/graphql-http": {
+		"node_modules/harper/node_modules/graphql-http": {
 			"version": "1.22.4",
-			"resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.22.4.tgz",
-			"integrity": "sha512-OC3ucK988teMf+Ak/O+ZJ0N2ukcgrEurypp8ePyJFWq83VzwRAmHxxr+XxrMpxO/FIwI4a7m/Fzv3tWGJv0wPA==",
 			"dev": true,
 			"license": "MIT",
 			"workspaces": [
@@ -5688,10 +6473,8 @@
 				"graphql": ">=0.11 <=16"
 			}
 		},
-		"node_modules/gunzip-maybe": {
+		"node_modules/harper/node_modules/gunzip-maybe": {
 			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.2.tgz",
-			"integrity": "sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5706,10 +6489,19 @@
 				"gunzip-maybe": "bin.js"
 			}
 		},
-		"node_modules/gunzip-maybe/node_modules/pump": {
+		"node_modules/harper/node_modules/gunzip-maybe/node_modules/duplexify": {
+			"version": "3.7.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0",
+				"stream-shift": "^1.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/gunzip-maybe/node_modules/pump": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5717,10 +6509,8 @@
 				"once": "^1.3.1"
 			}
 		},
-		"node_modules/gunzip-maybe/node_modules/pumpify": {
+		"node_modules/harper/node_modules/gunzip-maybe/node_modules/pumpify": {
 			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5729,121 +6519,16 @@
 				"pump": "^2.0.0"
 			}
 		},
-		"node_modules/harper": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/harper/-/harper-5.0.9.tgz",
-			"integrity": "sha512-U0p70Qu/hza/iHnFU3hbuKxwzCMwQ4Zf0TBo60d7fFNN/1ZoZ829cuX9d6CHYLFebNE2H6PZRB54gsF2+WMlsw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/client-s3": "^3.1012.0",
-				"@aws-sdk/lib-storage": "3.1024.0",
-				"@datadog/pprof": "^5.11.1",
-				"@endo/static-module-record": "^1.1.2",
-				"@fastify/autoload": "^6.3.1",
-				"@fastify/compress": "^8.3.1",
-				"@fastify/cors": "^11.2.0",
-				"@fastify/static": "^9.1.3",
-				"@harperfast/extended-iterable": "^1.0.1",
-				"@harperfast/rocksdb-js": "^1.1.0",
-				"@turf/area": "6.5.0",
-				"@turf/boolean-contains": "6.5.0",
-				"@turf/boolean-disjoint": "6.5.0",
-				"@turf/boolean-equal": "6.5.0",
-				"@turf/circle": "6.5.0",
-				"@turf/difference": "6.5.0",
-				"@turf/distance": "6.5.0",
-				"@turf/helpers": "6.5.0",
-				"@turf/length": "6.5.0",
-				"alasql": "4.6.6",
-				"amaro": "^1.1.8",
-				"argon2": "0.44.0",
-				"asn1js": "3.0.7",
-				"cbor-x": "1.6.4",
-				"chalk": "4.1.2",
-				"chokidar": "^4.0.3",
-				"cli-progress": "3.12.0",
-				"clone": "2.1.2",
-				"dotenv": "^16.4.7",
-				"easy-ocsp": "1.3.1",
-				"fast-glob": "3.3.3",
-				"fastify": "^5.8.2",
-				"fastify-plugin": "^5.1.0",
-				"fs-extra": "11.3.4",
-				"graphql": "^16.10.0",
-				"graphql-http": "^1.22.4",
-				"gunzip-maybe": "1.4.2",
-				"human-readable-ids": "1.0.4",
-				"inquirer": "8.2.7",
-				"is-number": "7.0.0",
-				"joi": "17.13.3",
-				"json-bigint-fixes": "1.1.0",
-				"jsonata": "1.8.7",
-				"jsonwebtoken": "9.0.3",
-				"lmdb": "3.5.4",
-				"lodash": "^4.17.23",
-				"mathjs": "11.12.0",
-				"micromatch": "^4.0.8",
-				"minimist": "1.2.8",
-				"moment": "2.30.1",
-				"mqtt-packet": "~9.0.1",
-				"msgpackr": "1.11.9",
-				"needle": "3.5.0",
-				"node-forge": "^1.3.1",
-				"node-stream-zip": "1.15.0",
-				"node-unix-socket": "0.2.7",
-				"normalize-path": "^3.0.0",
-				"ora": "8.2.0",
-				"ordered-binary": "1.6.1",
-				"papaparse": "5.5.3",
-				"passport": "0.7.0",
-				"passport-http": "0.3.0",
-				"passport-local": "1.0.0",
-				"pino": "8.21.0",
-				"pkijs": "3.4.0",
-				"prompt": "1.3.0",
-				"properties-reader": "2.3.0",
-				"recursive-iterator": "3.3.0",
-				"semver": "7.7.4",
-				"send": "^1.2.0",
-				"ses": "^1.15.0",
-				"stream-chain": "2.2.5",
-				"stream-json": "1.9.1",
-				"systeminformation": "^5.31.4",
-				"tar-fs": "^3.1.2",
-				"ulidx": "0.5.0",
-				"uuid": "11.1.0",
-				"validate.js": "0.13.1",
-				"ws": "8.20.0",
-				"yaml": "2.8.3"
-			},
-			"bin": {
-				"harper": "dist/bin/harper.js"
-			},
-			"engines": {
-				"minimum-node": "20.0.0",
-				"node": ">=20"
-			},
-			"optionalDependencies": {
-				"bufferutil": "^4.0.9",
-				"segfault-handler": "^1.3.0",
-				"utf-8-validate": "^5.0.10"
-			}
-		},
-		"node_modules/has-flag": {
+		"node_modules/harper/node_modules/has-flag": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
-		"node_modules/has-property-descriptors": {
+		"node_modules/harper/node_modules/has-property-descriptors": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5853,10 +6538,8 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/has-symbols": {
+		"node_modules/harper/node_modules/has-symbols": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5866,10 +6549,8 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/has-tostringtag": {
+		"node_modules/harper/node_modules/has-tostringtag": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5882,10 +6563,8 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/hasown": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+		"node_modules/harper/node_modules/hasown": {
+			"version": "2.0.2",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5895,10 +6574,38 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/http-errors": {
+		"node_modules/harper/node_modules/hermes-compiler": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-0.0.0.tgz",
+			"integrity": "sha512-boVFutx6ME/Km2mB6vvsQcdnazEYYI/jV1pomx1wcFUG/EVqTkr5CU0CW9bKipOA/8Hyu3NYwW3THg2Q1kNCfA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/hermes-estree": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
+			"integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/hermes-parser": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
+			"integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"hermes-estree": "0.32.0"
+			}
+		},
+		"node_modules/harper/node_modules/http-errors": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5916,20 +6623,32 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/human-readable-ids": {
+		"node_modules/harper/node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/harper/node_modules/human-readable-ids": {
 			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/human-readable-ids/-/human-readable-ids-1.0.4.tgz",
-			"integrity": "sha512-h1zwThTims8A/SpqFGWyTx+jG1+WRMJaEeZgbtPGrIpj2AZjsOgy8Y+iNzJ0yAyN669Q6F02EK66WMWcst+2FA==",
 			"dev": true,
 			"license": "Apache2",
 			"dependencies": {
 				"knuth-shuffle": "^1.0.0"
 			}
 		},
-		"node_modules/iconv-lite": {
+		"node_modules/harper/node_modules/iconv-lite": {
 			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5943,10 +6662,8 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/ieee754": {
+		"node_modules/harper/node_modules/ieee754": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
 			"dev": true,
 			"funding": [
 				{
@@ -5964,17 +6681,55 @@
 			],
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/inherits": {
+		"node_modules/harper/node_modules/image-size": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+			"integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"queue": "6.0.2"
+			},
+			"bin": {
+				"image-size": "bin/image-size.js"
+			},
+			"engines": {
+				"node": ">=16.x"
+			}
+		},
+		"node_modules/harper/node_modules/imurmurhash": {
+			"version": "0.1.4",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/harper/node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/harper/node_modules/inherits": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/inquirer": {
+		"node_modules/harper/node_modules/inquirer": {
 			"version": "8.2.7",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.7.tgz",
-			"integrity": "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5998,10 +6753,8 @@
 				"node": ">=12.0.0"
 			}
 		},
-		"node_modules/inquirer/node_modules/bl": {
+		"node_modules/harper/node_modules/inquirer/node_modules/bl": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6010,50 +6763,16 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
-		"node_modules/inquirer/node_modules/is-interactive": {
+		"node_modules/harper/node_modules/inquirer/node_modules/is-interactive": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
-		"node_modules/inquirer/node_modules/is-unicode-supported": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/inquirer/node_modules/log-symbols": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.0",
-				"is-unicode-supported": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/inquirer/node_modules/ora": {
+		"node_modules/harper/node_modules/inquirer/node_modules/ora": {
 			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-			"integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6074,10 +6793,8 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/inquirer/node_modules/readable-stream": {
+		"node_modules/harper/node_modules/inquirer/node_modules/readable-stream": {
 			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6089,20 +6806,28 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/ipaddr.js": {
+		"node_modules/harper/node_modules/invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"loose-envify": "^1.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/ipaddr.js": {
 			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
-			"integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10"
 			}
 		},
-		"node_modules/is-arguments": {
+		"node_modules/harper/node_modules/is-arguments": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-			"integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6116,10 +6841,8 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-date-object": {
+		"node_modules/harper/node_modules/is-date-object": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
-			"integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6133,37 +6856,47 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-deflate": {
+		"node_modules/harper/node_modules/is-deflate": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
-			"integrity": "sha512-YDoFpuZWu1VRXlsnlYMzKyVRITXj7Ej/V9gXQ2/pAe7X1J7M/RNOqaIYi6qUn+B7nGyB9pDXrv02dsB58d2ZAQ==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/is-extglob": {
+		"node_modules/harper/node_modules/is-docker": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/harper/node_modules/is-extglob": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-fullwidth-code-point": {
+		"node_modules/harper/node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
-		"node_modules/is-glob": {
+		"node_modules/harper/node_modules/is-glob": {
 			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6173,20 +6906,16 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-gzip": {
+		"node_modules/harper/node_modules/is-gzip": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
-			"integrity": "sha512-rcfALRIb1YewtnksfRIHGcIY93QnK8BIQ/2c9yDYcG/Y6+vRoJuTWBmmSEbyLLYtXm7q35pHOHbZFQBaLrhlWQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-interactive": {
+		"node_modules/harper/node_modules/is-interactive": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-			"integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6196,20 +6925,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-number": {
+		"node_modules/harper/node_modules/is-number": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
 			}
 		},
-		"node_modules/is-regex": {
+		"node_modules/harper/node_modules/is-regex": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6225,51 +6950,287 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-unicode-supported": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-			"integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+		"node_modules/harper/node_modules/is-unicode-supported": {
+			"version": "0.1.0",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/isarray": {
+		"node_modules/harper/node_modules/is-wsl": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"is-docker": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/isarray": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/isexe": {
+		"node_modules/harper/node_modules/isexe": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/isstream": {
+		"node_modules/harper/node_modules/isstream": {
 			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/javascript-natural-sort": {
+		"node_modules/harper/node_modules/istanbul-lib-coverage": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/istanbul-lib-instrument": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+			"integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/core": "^7.12.3",
+				"@babel/parser": "^7.14.7",
+				"@istanbuljs/schema": "^0.1.2",
+				"istanbul-lib-coverage": "^3.2.0",
+				"semver": "^6.3.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/istanbul-lib-instrument/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/harper/node_modules/javascript-natural-sort": {
 			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
-			"integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/joi": {
-			"version": "17.13.3",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-			"integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+		"node_modules/harper/node_modules/jest-environment-node": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jest/environment": "^29.7.0",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/jest-get-type": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+			"integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/jest-haste-map": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+			"integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/graceful-fs": "^4.1.3",
+				"@types/node": "*",
+				"anymatch": "^3.0.3",
+				"fb-watchman": "^2.0.0",
+				"graceful-fs": "^4.2.9",
+				"jest-regex-util": "^29.6.3",
+				"jest-util": "^29.7.0",
+				"jest-worker": "^29.7.0",
+				"micromatch": "^4.0.4",
+				"walker": "^1.0.8"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "^2.3.2"
+			}
+		},
+		"node_modules/harper/node_modules/jest-message-util": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.12.13",
+				"@jest/types": "^29.6.3",
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/jest-mock": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/jest-regex-util": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+			"integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/jest-util": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/jest-validate": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+			"integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"camelcase": "^6.2.0",
+				"chalk": "^4.0.0",
+				"jest-get-type": "^29.6.3",
+				"leven": "^3.1.0",
+				"pretty-format": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/jest-worker": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+			"integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*",
+				"jest-util": "^29.7.0",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/jest-worker/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/harper/node_modules/joi": {
+			"version": "17.13.4",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+			"integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -6280,16 +7241,22 @@
 				"@sideway/pinpoint": "^2.0.0"
 			}
 		},
-		"node_modules/js-tokens": {
+		"node_modules/harper/node_modules/js-tokens": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/jsesc": {
+		"node_modules/harper/node_modules/jsc-safe-url": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/jsc-safe-url/-/jsc-safe-url-0.2.4.tgz",
+			"integrity": "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==",
+			"dev": true,
+			"license": "0BSD",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/jsesc": {
 			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -6299,20 +7266,16 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/json-bigint-fixes": {
+		"node_modules/harper/node_modules/json-bigint-fixes": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/json-bigint-fixes/-/json-bigint-fixes-1.1.0.tgz",
-			"integrity": "sha512-B7275mgf4DP0x+kB0FciiIGjLFxWF8G1BKXmFURJE1Ro2sVBW3grdn5lYtQCVm+zS9ipgoSs8c6VeGClflvKEA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bignumber.js": "^9.0.0"
 			}
 		},
-		"node_modules/json-schema-ref-resolver": {
+		"node_modules/harper/node_modules/json-schema-ref-resolver": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
-			"integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
 			"dev": true,
 			"funding": [
 				{
@@ -6329,27 +7292,31 @@
 				"dequal": "^2.0.3"
 			}
 		},
-		"node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+		"node_modules/harper/node_modules/json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
 		},
-		"node_modules/jsonata": {
+		"node_modules/harper/node_modules/jsonata": {
 			"version": "1.8.7",
-			"resolved": "https://registry.npmjs.org/jsonata/-/jsonata-1.8.7.tgz",
-			"integrity": "sha512-tOW2/hZ+nR2bcQZs+0T62LVe5CHaNa3laFFWb/262r39utN6whJGBF7IR2Wq1QXrDbhftolk5gggW8uUJYlBTQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
 			}
 		},
-		"node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+		"node_modules/harper/node_modules/jsonfile": {
+			"version": "6.2.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6359,10 +7326,8 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
-		"node_modules/jsonwebtoken": {
+		"node_modules/harper/node_modules/jsonwebtoken": {
 			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
-			"integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6382,10 +7347,8 @@
 				"npm": ">=6"
 			}
 		},
-		"node_modules/jwa": {
+		"node_modules/harper/node_modules/jwa": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6394,10 +7357,8 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"node_modules/jws": {
+		"node_modules/harper/node_modules/jws": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6405,24 +7366,30 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"node_modules/knuth-shuffle": {
+		"node_modules/harper/node_modules/knuth-shuffle": {
 			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/knuth-shuffle/-/knuth-shuffle-1.0.8.tgz",
-			"integrity": "sha512-IdC4Hpp+mx53zTt6VAGsAtbGM0g4BV9fP8tTcviCosSwocHcRDw9uG5Rnv6wLWckF4r72qeXFoK9NkvV1gUJCQ==",
 			"dev": true,
 			"license": "(MIT OR Apache-2.0)"
 		},
-		"node_modules/layerr": {
+		"node_modules/harper/node_modules/layerr": {
 			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/layerr/-/layerr-0.1.2.tgz",
-			"integrity": "sha512-ob5kTd9H3S4GOG2nVXyQhOu9O8nBgP555XxWPkJI0tR0JeRilfyTp8WtPdIJHLXBmHMSdEq5+KMxiYABeScsIQ==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/light-my-request": {
+		"node_modules/harper/node_modules/leven": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/harper/node_modules/light-my-request": {
 			"version": "6.6.0",
-			"resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
-			"integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
 			"dev": true,
 			"funding": [
 				{
@@ -6441,10 +7408,8 @@
 				"set-cookie-parser": "^2.6.0"
 			}
 		},
-		"node_modules/light-my-request/node_modules/process-warning": {
+		"node_modules/harper/node_modules/light-my-request/node_modules/process-warning": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
-			"integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -6458,10 +7423,44 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/lmdb": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/lmdb/-/lmdb-3.5.4.tgz",
-			"integrity": "sha512-9FKQA6G1MMtqNxfxvSBNXD/axeG2QRjYbNh0/ykRL5xYcRbCm2vXq7B9bhc7nSuKdHzr8/BHIwfPuYYH1UsXXw==",
+		"node_modules/harper/node_modules/lighthouse-logger": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
+			"integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"debug": "^2.6.9",
+				"marky": "^1.2.2"
+			}
+		},
+		"node_modules/harper/node_modules/lighthouse-logger/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/lighthouse-logger/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/lmdb": {
+			"version": "3.5.6",
+			"resolved": "https://registry.npmjs.org/lmdb/-/lmdb-3.5.6.tgz",
+			"integrity": "sha512-j3uE8ReKNyUWDjhfEFSJqE/1DLtfTR5Z8yFzVHvBjAk37wNg7HdScjcv8ttPHRvrdgPQMPWxFFI0SsdBzI5lBw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -6477,23 +7476,33 @@
 				"download-lmdb-prebuilds": "bin/download-prebuilds.js"
 			},
 			"optionalDependencies": {
-				"@lmdb/lmdb-darwin-arm64": "3.5.4",
-				"@lmdb/lmdb-darwin-x64": "3.5.4",
-				"@lmdb/lmdb-linux-arm": "3.5.4",
-				"@lmdb/lmdb-linux-arm64": "3.5.4",
-				"@lmdb/lmdb-linux-x64": "3.5.4",
-				"@lmdb/lmdb-win32-arm64": "3.5.4",
-				"@lmdb/lmdb-win32-x64": "3.5.4"
+				"@lmdb/lmdb-darwin-arm64": "3.5.6",
+				"@lmdb/lmdb-darwin-x64": "3.5.6",
+				"@lmdb/lmdb-linux-arm": "3.5.6",
+				"@lmdb/lmdb-linux-arm64": "3.5.6",
+				"@lmdb/lmdb-linux-x64": "3.5.6",
+				"@lmdb/lmdb-win32-arm64": "3.5.6",
+				"@lmdb/lmdb-win32-x64": "3.5.6"
 			}
 		},
-		"node_modules/lmdb/node_modules/node-addon-api": {
+		"node_modules/harper/node_modules/lmdb/node_modules/msgpackr": {
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.12.1.tgz",
+			"integrity": "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==",
+			"dev": true,
+			"license": "MIT",
+			"optionalDependencies": {
+				"msgpackr-extract": "^3.0.2"
+			}
+		},
+		"node_modules/harper/node_modules/lmdb/node_modules/node-addon-api": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
 			"integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/lmdb/node_modules/node-gyp-build-optional-packages": {
+		"node_modules/harper/node_modules/lmdb/node_modules/node-gyp-build-optional-packages": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
 			"integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
@@ -6508,110 +7517,77 @@
 				"node-gyp-build-optional-packages-test": "build-test.js"
 			}
 		},
-		"node_modules/lodash": {
+		"node_modules/harper/node_modules/lodash": {
 			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/lodash.includes": {
+		"node_modules/harper/node_modules/lodash.includes": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/lodash.isboolean": {
+		"node_modules/harper/node_modules/lodash.isboolean": {
 			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/lodash.isinteger": {
+		"node_modules/harper/node_modules/lodash.isinteger": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/lodash.isnumber": {
+		"node_modules/harper/node_modules/lodash.isnumber": {
 			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/lodash.isplainobject": {
+		"node_modules/harper/node_modules/lodash.isplainobject": {
 			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/lodash.isstring": {
+		"node_modules/harper/node_modules/lodash.isstring": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/lodash.once": {
+		"node_modules/harper/node_modules/lodash.once": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/log-symbols": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
-			"integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+		"node_modules/harper/node_modules/lodash.throttle": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+			"integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/log-symbols": {
+			"version": "4.1.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"chalk": "^5.3.0",
-				"is-unicode-supported": "^1.3.0"
+				"chalk": "^4.1.0",
+				"is-unicode-supported": "^0.1.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/log-symbols/node_modules/chalk": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/log-symbols/node_modules/is-unicode-supported": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-			"integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/loose-envify": {
+		"node_modules/harper/node_modules/loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
 			"license": "MIT",
+			"optional": true,
 			"peer": true,
 			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
@@ -6620,30 +7596,37 @@
 				"loose-envify": "cli.js"
 			}
 		},
-		"node_modules/lru-cache": {
-			"version": "11.3.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-			"integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+		"node_modules/harper/node_modules/makeerror": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+			"integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
 			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": "20 || >=22"
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tmpl": "1.0.5"
 			}
 		},
-		"node_modules/math-intrinsics": {
+		"node_modules/harper/node_modules/marky": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+			"integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/math-intrinsics": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/mathjs": {
+		"node_modules/harper/node_modules/mathjs": {
 			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/mathjs/-/mathjs-11.12.0.tgz",
-			"integrity": "sha512-UGhVw8rS1AyedyI55DGz9q1qZ0p98kyKPyc9vherBkoueLntPfKtPBh14x+V4cdUWK0NZV2TBwqRFlvadscSuw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -6664,20 +7647,532 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/merge2": {
+		"node_modules/harper/node_modules/memoize-one": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+			"integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/merge2": {
 			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
 			}
 		},
-		"node_modules/micromatch": {
+		"node_modules/harper/node_modules/metro": {
+			"version": "0.83.7",
+			"resolved": "https://registry.npmjs.org/metro/-/metro-0.83.7.tgz",
+			"integrity": "sha512-SPaPEyvTsTmd0LpT7RaZciQyDw2i/JB7+iY9L5VfBo72+psescFxBqpI1TL9dnL+pmnfkU+l/J1mEEGLeF65EQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.29.0",
+				"@babel/core": "^7.25.2",
+				"@babel/generator": "^7.29.1",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"accepts": "^2.0.0",
+				"ci-info": "^2.0.0",
+				"connect": "^3.6.5",
+				"debug": "^4.4.0",
+				"error-stack-parser": "^2.0.6",
+				"flow-enums-runtime": "^0.0.6",
+				"graceful-fs": "^4.2.4",
+				"hermes-parser": "0.35.0",
+				"image-size": "^1.0.2",
+				"invariant": "^2.2.4",
+				"jest-worker": "^29.7.0",
+				"jsc-safe-url": "^0.2.2",
+				"lodash.throttle": "^4.1.1",
+				"metro-babel-transformer": "0.83.7",
+				"metro-cache": "0.83.7",
+				"metro-cache-key": "0.83.7",
+				"metro-config": "0.83.7",
+				"metro-core": "0.83.7",
+				"metro-file-map": "0.83.7",
+				"metro-resolver": "0.83.7",
+				"metro-runtime": "0.83.7",
+				"metro-source-map": "0.83.7",
+				"metro-symbolicate": "0.83.7",
+				"metro-transform-plugins": "0.83.7",
+				"metro-transform-worker": "0.83.7",
+				"mime-types": "^3.0.1",
+				"nullthrows": "^1.1.1",
+				"serialize-error": "^2.1.0",
+				"source-map": "^0.5.6",
+				"throat": "^5.0.0",
+				"ws": "^7.5.10",
+				"yargs": "^17.6.2"
+			},
+			"bin": {
+				"metro": "src/cli.js"
+			},
+			"engines": {
+				"node": ">=20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/metro-babel-transformer": {
+			"version": "0.83.7",
+			"resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.7.tgz",
+			"integrity": "sha512-sBqBkt6kNut/88bv+Ucvm4yqdPetbvAEsHzi3MAgJEifOSYYzX5Z5Kgw3TFOrwf/mHJTOBG2ONlaMHoyfP15TA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/core": "^7.25.2",
+				"flow-enums-runtime": "^0.0.6",
+				"hermes-parser": "0.35.0",
+				"metro-cache-key": "0.83.7",
+				"nullthrows": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/metro-babel-transformer/node_modules/hermes-estree": {
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+			"integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/metro-babel-transformer/node_modules/hermes-parser": {
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+			"integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"hermes-estree": "0.35.0"
+			}
+		},
+		"node_modules/harper/node_modules/metro-cache": {
+			"version": "0.83.7",
+			"resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.7.tgz",
+			"integrity": "sha512-E9SRePXQ1Zvlj79VcOk57q7VC7rMHMFQ+jhmPHBiq+dJ0bJB5BL87lWZF6oh5X76Cci5tpDuQNaDwwuSCToEeg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"exponential-backoff": "^3.1.1",
+				"flow-enums-runtime": "^0.0.6",
+				"https-proxy-agent": "^7.0.5",
+				"metro-core": "0.83.7"
+			},
+			"engines": {
+				"node": ">=20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/metro-cache-key": {
+			"version": "0.83.7",
+			"resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.7.tgz",
+			"integrity": "sha512-W1c2Nmx8MiJTJt+eWhMO08z9VKi3kZOaz99IYGdqeqDgY9j+yZjXl62rUav4Di0heZfh4/n2s722PqRL1OODeg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"flow-enums-runtime": "^0.0.6"
+			},
+			"engines": {
+				"node": ">=20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/metro-config": {
+			"version": "0.83.7",
+			"resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.7.tgz",
+			"integrity": "sha512-83mjWFbFOt2GeJ6pFIum5mSnc1uTsZJAtD8o4ej0s4NVsYsA7fB+pHvTfHhFrpeMONaobu2riKavkPei05Er/Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"connect": "^3.6.5",
+				"flow-enums-runtime": "^0.0.6",
+				"jest-validate": "^29.7.0",
+				"metro": "0.83.7",
+				"metro-cache": "0.83.7",
+				"metro-core": "0.83.7",
+				"metro-runtime": "0.83.7",
+				"yaml": "^2.6.1"
+			},
+			"engines": {
+				"node": ">=20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/metro-core": {
+			"version": "0.83.7",
+			"resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.7.tgz",
+			"integrity": "sha512-6yn3w1wnltT6RQl7p7YES2l95ArC+mWrOssEiH8p5/DDrJS65/szf9LsC9JrBv8c5DdvSY3V3f0GRYg0Ox7hCg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"flow-enums-runtime": "^0.0.6",
+				"lodash.throttle": "^4.1.1",
+				"metro-resolver": "0.83.7"
+			},
+			"engines": {
+				"node": ">=20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/metro-file-map": {
+			"version": "0.83.7",
+			"resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.7.tgz",
+			"integrity": "sha512-+j0F1m+FQYVAQ6syf+mwhIPV5GoFQrkInX8bppuc50IzNsZbMrp8R5H/Sx/K2daQ3YEa9F/XwkeZT8gzJfgeCw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.4.0",
+				"fb-watchman": "^2.0.0",
+				"flow-enums-runtime": "^0.0.6",
+				"graceful-fs": "^4.2.4",
+				"invariant": "^2.2.4",
+				"jest-worker": "^29.7.0",
+				"micromatch": "^4.0.4",
+				"nullthrows": "^1.1.1",
+				"walker": "^1.0.7"
+			},
+			"engines": {
+				"node": ">=20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/metro-minify-terser": {
+			"version": "0.83.7",
+			"resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.7.tgz",
+			"integrity": "sha512-MfJar2IS4tBRuLb9svwb0Gu5l9BsH+pcRm8eGcEi/wy8MzZinfinh5dFLt2nWkocnulIgtGB5NkFDdbXqMXKhQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"flow-enums-runtime": "^0.0.6",
+				"terser": "^5.15.0"
+			},
+			"engines": {
+				"node": ">=20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/metro-resolver": {
+			"version": "0.83.7",
+			"resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.7.tgz",
+			"integrity": "sha512-WSJIENlMcoSsuz66IfBHOkgfp3KJt2UW2TnEHPf1b8pIG2eEXNOVmo2+03A0H17WY2XGXWgxL0CG7FAopqgB1A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"flow-enums-runtime": "^0.0.6"
+			},
+			"engines": {
+				"node": ">=20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/metro-runtime": {
+			"version": "0.83.7",
+			"resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.7.tgz",
+			"integrity": "sha512-9GKkJURaB2iyYoEExKnedzAHzxmKtSi+k0tsZUvMoU27tBZJElchYt7JH/Ai/XzYAI9lCAaV7u5HZSI8J5Z+wQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.25.0",
+				"flow-enums-runtime": "^0.0.6"
+			},
+			"engines": {
+				"node": ">=20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/metro-source-map": {
+			"version": "0.83.7",
+			"resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.7.tgz",
+			"integrity": "sha512-JgA1h7oc1a1jydBe1GhVFsUoMYo3wLPk7oRA32rjlDsq+sP2JLt9x2p2lWbNSxTm/u8NV4VRid3hvEJgcX8tKw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/traverse": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"flow-enums-runtime": "^0.0.6",
+				"invariant": "^2.2.4",
+				"metro-symbolicate": "0.83.7",
+				"nullthrows": "^1.1.1",
+				"ob1": "0.83.7",
+				"source-map": "^0.5.6",
+				"vlq": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/metro-source-map/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/harper/node_modules/metro-symbolicate": {
+			"version": "0.83.7",
+			"resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.7.tgz",
+			"integrity": "sha512-g4suyxw20WOHWI680c+Kq4wC/NF+Hx5pRH9afrMp+sMTxqLeKcPR1Xf4wMhsjlbvx7LbIREdke6q928jEjvJWw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"flow-enums-runtime": "^0.0.6",
+				"invariant": "^2.2.4",
+				"metro-source-map": "0.83.7",
+				"nullthrows": "^1.1.1",
+				"source-map": "^0.5.6",
+				"vlq": "^1.0.0"
+			},
+			"bin": {
+				"metro-symbolicate": "src/index.js"
+			},
+			"engines": {
+				"node": ">=20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/metro-symbolicate/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/harper/node_modules/metro-transform-plugins": {
+			"version": "0.83.7",
+			"resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.7.tgz",
+			"integrity": "sha512-Ss0FpBiZDjX2kwhukMDl5sNdYK8T/06IPqxNE4H6PTlRlfs9q11cef13c/xESY/Pm4VCkp1yJUZO3kXzvMxQFA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/core": "^7.25.2",
+				"@babel/generator": "^7.29.1",
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.29.0",
+				"flow-enums-runtime": "^0.0.6",
+				"nullthrows": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/metro-transform-worker": {
+			"version": "0.83.7",
+			"resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.7.tgz",
+			"integrity": "sha512-UegCo7ygB2fT64mRK2nbAjQVJ1zSwIIHy8d96jJv2nKZFDaViYBiughEdu5HM/Ceq0WN3LZrZk3zhl9aoiLYFw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/core": "^7.25.2",
+				"@babel/generator": "^7.29.1",
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"flow-enums-runtime": "^0.0.6",
+				"metro": "0.83.7",
+				"metro-babel-transformer": "0.83.7",
+				"metro-cache": "0.83.7",
+				"metro-cache-key": "0.83.7",
+				"metro-minify-terser": "0.83.7",
+				"metro-source-map": "0.83.7",
+				"metro-transform-plugins": "0.83.7",
+				"nullthrows": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/metro/node_modules/ci-info": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/metro/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/harper/node_modules/metro/node_modules/hermes-estree": {
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+			"integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/metro/node_modules/hermes-parser": {
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+			"integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"hermes-estree": "0.35.0"
+			}
+		},
+		"node_modules/harper/node_modules/metro/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/harper/node_modules/metro/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/harper/node_modules/metro/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/harper/node_modules/metro/node_modules/ws": {
+			"version": "7.5.11",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+			"integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/harper/node_modules/metro/node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/harper/node_modules/micromatch": {
 			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6688,10 +8183,8 @@
 				"node": ">=8.6"
 			}
 		},
-		"node_modules/mime": {
+		"node_modules/harper/node_modules/mime": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -6701,20 +8194,1743 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/mime-db": {
+		"node_modules/harper/node_modules/mime-db": {
 			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/mime-types": {
+		"node_modules/harper/node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/harper/node_modules/mimic-function": {
+			"version": "5.0.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/harper/node_modules/minimatch": {
+			"version": "10.2.4",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/harper/node_modules/minimist": {
+			"version": "1.2.8",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/harper/node_modules/minipass": {
+			"version": "7.1.3",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/harper/node_modules/mkdirp": {
+			"version": "1.0.4",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/harper/node_modules/moment": {
+			"version": "2.30.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/harper/node_modules/mqtt-packet": {
+			"version": "9.0.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bl": "^6.0.8",
+				"debug": "^4.3.4",
+				"process-nextick-args": "^2.0.1"
+			}
+		},
+		"node_modules/harper/node_modules/ms": {
+			"version": "2.1.3",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/msgpackr": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.4.tgz",
+			"integrity": "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==",
+			"dev": true,
+			"license": "MIT",
+			"optionalDependencies": {
+				"msgpackr-extract": "^3.0.4"
+			}
+		},
+		"node_modules/harper/node_modules/msgpackr-extract": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+			"integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"node-gyp-build-optional-packages": "5.2.2"
+			},
+			"bin": {
+				"download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+			},
+			"optionalDependencies": {
+				"@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+				"@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+				"@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+				"@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+				"@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+				"@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+			}
+		},
+		"node_modules/harper/node_modules/msgpackr-extract/node_modules/node-gyp-build-optional-packages": {
+			"version": "5.2.2",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"detect-libc": "^2.0.1"
+			},
+			"bin": {
+				"node-gyp-build-optional-packages": "bin.js",
+				"node-gyp-build-optional-packages-optional": "optional.js",
+				"node-gyp-build-optional-packages-test": "build-test.js"
+			}
+		},
+		"node_modules/harper/node_modules/mute-stream": {
+			"version": "0.0.8",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/harper/node_modules/nan": {
+			"version": "2.25.0",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/harper/node_modules/needle": {
+			"version": "3.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"iconv-lite": "^0.6.3",
+				"sax": "^1.2.4"
+			},
+			"bin": {
+				"needle": "bin/needle"
+			},
+			"engines": {
+				"node": ">= 4.4.x"
+			}
+		},
+		"node_modules/harper/node_modules/needle/node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/harper/node_modules/negotiator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/harper/node_modules/node-addon-api": {
+			"version": "8.6.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18 || ^20 || >= 21"
+			}
+		},
+		"node_modules/harper/node_modules/node-fetch": {
+			"version": "2.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/harper/node_modules/node-forge": {
+			"version": "1.4.0",
+			"dev": true,
+			"license": "(BSD-3-Clause OR GPL-2.0)",
+			"engines": {
+				"node": ">= 6.13.0"
+			}
+		},
+		"node_modules/harper/node_modules/node-gyp-build-optional-packages": {
+			"version": "5.1.1",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"detect-libc": "^2.0.1"
+			},
+			"bin": {
+				"node-gyp-build-optional-packages": "bin.js",
+				"node-gyp-build-optional-packages-optional": "optional.js",
+				"node-gyp-build-optional-packages-test": "build-test.js"
+			}
+		},
+		"node_modules/harper/node_modules/node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/node-releases": {
+			"version": "2.0.46",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+			"integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/harper/node_modules/node-stream-zip": {
+			"version": "1.15.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.12.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/antelle"
+			}
+		},
+		"node_modules/harper/node_modules/normalize-path": {
+			"version": "3.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/harper/node_modules/nullthrows": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+			"integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/ob1": {
+			"version": "0.83.7",
+			"resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.7.tgz",
+			"integrity": "sha512-9M5kpuOLyTPogMtZiQUIxdAZxl7Dxs6tVBbJErSumsqGMuhVSoUbkfeZ3XNPpLpwBBtqY5QDUzGwggLHX3slQg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"flow-enums-runtime": "^0.0.6"
+			},
+			"engines": {
+				"node": ">=20.19.4"
+			}
+		},
+		"node_modules/harper/node_modules/object-is": {
+			"version": "1.1.6",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/harper/node_modules/object-keys": {
+			"version": "1.1.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/harper/node_modules/on-exit-leak-free": {
+			"version": "2.1.2",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/on-finished": {
+			"version": "2.4.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/harper/node_modules/once": {
+			"version": "1.4.0",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/harper/node_modules/onetime": {
+			"version": "5.1.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/harper/node_modules/open": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+			"integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"is-docker": "^2.0.0",
+				"is-wsl": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/harper/node_modules/ora": {
+			"version": "8.2.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.3.0",
+				"cli-cursor": "^5.0.0",
+				"cli-spinners": "^2.9.2",
+				"is-interactive": "^2.0.0",
+				"is-unicode-supported": "^2.0.0",
+				"log-symbols": "^6.0.0",
+				"stdin-discarder": "^0.2.2",
+				"string-width": "^7.2.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/harper/node_modules/ora/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/harper/node_modules/ora/node_modules/chalk": {
+			"version": "5.6.2",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/harper/node_modules/ora/node_modules/cli-cursor": {
+			"version": "5.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"restore-cursor": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/harper/node_modules/ora/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/ora/node_modules/is-unicode-supported": {
+			"version": "2.1.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/harper/node_modules/ora/node_modules/log-symbols": {
+			"version": "6.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.3.0",
+				"is-unicode-supported": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/harper/node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
+			"version": "1.3.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/harper/node_modules/ora/node_modules/onetime": {
+			"version": "7.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-function": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/harper/node_modules/ora/node_modules/restore-cursor": {
+			"version": "5.1.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"onetime": "^7.0.0",
+				"signal-exit": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/harper/node_modules/ora/node_modules/string-width": {
+			"version": "7.2.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/harper/node_modules/ora/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/harper/node_modules/ordered-binary": {
+			"version": "1.6.1",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/harper/node_modules/pako": {
+			"version": "0.2.9",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/papaparse": {
+			"version": "5.5.4",
+			"resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.4.tgz",
+			"integrity": "sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/harper/node_modules/passport": {
+			"version": "0.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"passport-strategy": "1.x.x",
+				"pause": "0.0.1",
+				"utils-merge": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/jaredhanson"
+			}
+		},
+		"node_modules/harper/node_modules/passport-http": {
+			"version": "0.3.0",
+			"dev": true,
+			"dependencies": {
+				"passport-strategy": "1.x.x"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/harper/node_modules/passport-local": {
+			"version": "1.0.0",
+			"dev": true,
+			"dependencies": {
+				"passport-strategy": "1.x.x"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/harper/node_modules/passport-strategy": {
+			"version": "1.0.0",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/harper/node_modules/path-exists": {
+			"version": "4.0.0",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/harper/node_modules/path-key": {
+			"version": "3.1.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/pause": {
+			"version": "0.0.1",
+			"dev": true
+		},
+		"node_modules/harper/node_modules/peek-stream": {
+			"version": "1.1.3",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"duplexify": "^3.5.0",
+				"through2": "^2.0.3"
+			}
+		},
+		"node_modules/harper/node_modules/peek-stream/node_modules/duplexify": {
+			"version": "3.7.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0",
+				"stream-shift": "^1.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/picocolors": {
+			"version": "1.1.1",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/harper/node_modules/picomatch": {
+			"version": "2.3.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/harper/node_modules/pino": {
+			"version": "8.21.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0",
+				"fast-redact": "^3.1.1",
+				"on-exit-leak-free": "^2.1.0",
+				"pino-abstract-transport": "^1.2.0",
+				"pino-std-serializers": "^6.0.0",
+				"process-warning": "^3.0.0",
+				"quick-format-unescaped": "^4.0.3",
+				"real-require": "^0.2.0",
+				"safe-stable-stringify": "^2.3.1",
+				"sonic-boom": "^3.7.0",
+				"thread-stream": "^2.6.0"
+			},
+			"bin": {
+				"pino": "bin.js"
+			}
+		},
+		"node_modules/harper/node_modules/pino-abstract-transport": {
+			"version": "3.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"split2": "^4.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/pino-std-serializers": {
+			"version": "6.2.2",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/pino/node_modules/buffer": {
+			"version": "6.0.3",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/harper/node_modules/pino/node_modules/pino-abstract-transport": {
+			"version": "1.2.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readable-stream": "^4.0.0",
+				"split2": "^4.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/pino/node_modules/process-warning": {
+			"version": "3.0.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/pino/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/pino/node_modules/split2": {
+			"version": "4.2.0",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 10.x"
+			}
+		},
+		"node_modules/harper/node_modules/pino/node_modules/string_decoder": {
+			"version": "1.3.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/harper/node_modules/pirates": {
+			"version": "4.0.7",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/harper/node_modules/pkijs": {
+			"version": "3.4.0",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@noble/hashes": "1.4.0",
+				"asn1js": "^3.0.6",
+				"bytestreamjs": "^2.0.1",
+				"pvtsutils": "^1.3.6",
+				"pvutils": "^1.1.3",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/pkijs/node_modules/@noble/hashes": {
+			"version": "1.4.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/harper/node_modules/polygon-clipping": {
+			"version": "0.15.7",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"robust-predicates": "^3.0.2",
+				"splaytree": "^3.1.0"
+			}
+		},
+		"node_modules/harper/node_modules/pretty-format": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jest/schemas": "^29.6.3",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^18.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/harper/node_modules/process": {
+			"version": "0.11.10",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
+		"node_modules/harper/node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/process-warning": {
+			"version": "5.0.0",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/promise": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+			"integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"asap": "~2.0.6"
+			}
+		},
+		"node_modules/harper/node_modules/prompt": {
+			"version": "1.3.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@colors/colors": "1.5.0",
+				"async": "3.2.3",
+				"read": "1.0.x",
+				"revalidator": "0.1.x",
+				"winston": "2.x"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/properties-reader": {
+			"version": "2.3.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mkdirp": "^1.0.4"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/steveukx/properties?sponsor=1"
+			}
+		},
+		"node_modules/harper/node_modules/pump": {
+			"version": "3.0.4",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/harper/node_modules/pumpify": {
+			"version": "2.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"duplexify": "^4.1.1",
+				"inherits": "^2.0.3",
+				"pump": "^3.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/pvtsutils": {
+			"version": "1.3.6",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/harper/node_modules/pvutils": {
+			"version": "1.1.5",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/queue": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+			"integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"inherits": "~2.0.3"
+			}
+		},
+		"node_modules/harper/node_modules/queue-microtask": {
+			"version": "1.2.3",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/quick-format-unescaped": {
+			"version": "4.0.4",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/quickselect": {
+			"version": "2.0.0",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/harper/node_modules/range-parser": {
+			"version": "1.2.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/harper/node_modules/rbush": {
+			"version": "3.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"quickselect": "^2.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/react": {
+			"version": "19.2.6",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+			"integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/harper/node_modules/react-devtools-core": {
+			"version": "6.1.5",
+			"resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.5.tgz",
+			"integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"shell-quote": "^1.6.1",
+				"ws": "^7"
+			}
+		},
+		"node_modules/harper/node_modules/react-devtools-core/node_modules/ws": {
+			"version": "7.5.11",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+			"integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/harper/node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/react-native": {
+			"version": "0.82.1",
+			"resolved": "https://registry.npmjs.org/react-native/-/react-native-0.82.1.tgz",
+			"integrity": "sha512-tFAqcU7Z4g49xf/KnyCEzI4nRTu1Opcx05Ov2helr8ZTg1z7AJR/3sr2rZ+AAVlAs2IXk+B0WOxXGmdD3+4czA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jest/create-cache-key-function": "^29.7.0",
+				"@react-native/assets-registry": "0.82.1",
+				"@react-native/codegen": "0.82.1",
+				"@react-native/community-cli-plugin": "0.82.1",
+				"@react-native/gradle-plugin": "0.82.1",
+				"@react-native/js-polyfills": "0.82.1",
+				"@react-native/normalize-colors": "0.82.1",
+				"@react-native/virtualized-lists": "0.82.1",
+				"abort-controller": "^3.0.0",
+				"anser": "^1.4.9",
+				"ansi-regex": "^5.0.0",
+				"babel-jest": "^29.7.0",
+				"babel-plugin-syntax-hermes-parser": "0.32.0",
+				"base64-js": "^1.5.1",
+				"commander": "^12.0.0",
+				"flow-enums-runtime": "^0.0.6",
+				"glob": "^7.1.1",
+				"hermes-compiler": "0.0.0",
+				"invariant": "^2.2.4",
+				"jest-environment-node": "^29.7.0",
+				"memoize-one": "^5.0.0",
+				"metro-runtime": "^0.83.1",
+				"metro-source-map": "^0.83.1",
+				"nullthrows": "^1.1.1",
+				"pretty-format": "^29.7.0",
+				"promise": "^8.3.0",
+				"react-devtools-core": "^6.1.5",
+				"react-refresh": "^0.14.0",
+				"regenerator-runtime": "^0.13.2",
+				"scheduler": "0.26.0",
+				"semver": "^7.1.3",
+				"stacktrace-parser": "^0.1.10",
+				"whatwg-fetch": "^3.0.0",
+				"ws": "^6.2.3",
+				"yargs": "^17.6.2"
+			},
+			"bin": {
+				"react-native": "cli.js"
+			},
+			"engines": {
+				"node": ">= 20.19.4"
+			},
+			"peerDependencies": {
+				"@types/react": "^19.1.1",
+				"react": "^19.1.1"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/harper/node_modules/react-native-fs": {
+			"version": "2.20.0",
+			"resolved": "https://registry.npmjs.org/react-native-fs/-/react-native-fs-2.20.0.tgz",
+			"integrity": "sha512-VkTBzs7fIDUiy/XajOSNk0XazFE9l+QlMAce7lGuebZcag5CnjszB+u4BdqzwaQOdcYb5wsJIsqq4kxInIRpJQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"base-64": "^0.1.0",
+				"utf8": "^3.0.0"
+			},
+			"peerDependencies": {
+				"react-native": "*",
+				"react-native-windows": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-windows": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/harper/node_modules/react-native/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/react-native/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/harper/node_modules/react-native/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/harper/node_modules/react-native/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/harper/node_modules/react-native/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/harper/node_modules/react-native/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/harper/node_modules/react-native/node_modules/ws": {
+			"version": "6.2.4",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.4.tgz",
+			"integrity": "sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"async-limiter": "~1.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/react-native/node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/harper/node_modules/react-refresh": {
+			"version": "0.14.2",
+			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+			"integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/harper/node_modules/read": {
+			"version": "1.0.7",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"mute-stream": "~0.0.4"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/harper/node_modules/readable-stream": {
+			"version": "2.3.8",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/harper/node_modules/readable-stream/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/readdirp": {
+			"version": "4.1.2",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.18.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/harper/node_modules/real-require": {
+			"version": "0.2.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12.13.0"
+			}
+		},
+		"node_modules/harper/node_modules/recursive-iterator": {
+			"version": "3.3.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/harper/node_modules/regenerator-runtime": {
+			"version": "0.13.11",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/regexp.prototype.flags": {
+			"version": "1.5.4",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"define-properties": "^1.2.1",
+				"es-errors": "^1.3.0",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"set-function-name": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/harper/node_modules/require-directory": {
+			"version": "2.1.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/harper/node_modules/require-from-string": {
+			"version": "2.0.2",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/harper/node_modules/restore-cursor": {
+			"version": "3.1.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/restore-cursor/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/harper/node_modules/ret": {
+			"version": "0.5.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/harper/node_modules/reusify": {
+			"version": "1.1.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/harper/node_modules/revalidator": {
+			"version": "0.1.8",
+			"dev": true,
+			"license": "Apache 2.0",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/harper/node_modules/rfdc": {
+			"version": "1.4.1",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/rimraf": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/harper/node_modules/rimraf/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/rimraf/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/harper/node_modules/rimraf/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/harper/node_modules/rimraf/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/harper/node_modules/robust-predicates": {
+			"version": "3.0.2",
+			"dev": true,
+			"license": "Unlicense"
+		},
+		"node_modules/harper/node_modules/run-async": {
+			"version": "2.4.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/harper/node_modules/run-parallel": {
+			"version": "1.2.0",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
+			}
+		},
+		"node_modules/harper/node_modules/rxjs": {
+			"version": "7.8.2",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/harper/node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/safe-regex2": {
+			"version": "5.1.0",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"ret": "~0.5.0"
+			},
+			"bin": {
+				"safe-regex2": "bin/safe-regex2.js"
+			}
+		},
+		"node_modules/harper/node_modules/safe-stable-stringify": {
+			"version": "2.5.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/harper/node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/sax": {
+			"version": "1.5.0",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=11.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/scheduler": {
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+			"integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/secure-json-parse": {
+			"version": "4.1.0",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/harper/node_modules/seedrandom": {
+			"version": "3.0.5",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/segfault-handler": {
+			"version": "1.3.0",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"dependencies": {
+				"bindings": "^1.2.1",
+				"nan": "^2.14.0"
+			}
+		},
+		"node_modules/harper/node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/harper/node_modules/send": {
+			"version": "1.2.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
+				"ms": "^2.1.3",
+				"on-finished": "^2.4.1",
+				"range-parser": "^1.2.1",
+				"statuses": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/harper/node_modules/send/node_modules/mime-types": {
+			"version": "3.0.2",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6728,20 +9944,359 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/mimic-fn": {
+		"node_modules/harper/node_modules/serialize-error": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+			"integrity": "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/harper/node_modules/serve-static": {
+			"version": "1.16.3",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+			"integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.3",
+				"send": "~0.19.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/harper/node_modules/serve-static/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/serve-static/node_modules/debug/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/serve-static/node_modules/fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/harper/node_modules/serve-static/node_modules/mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/harper/node_modules/serve-static/node_modules/send": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+			"integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"destroy": "1.2.0",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.1",
+				"mime": "1.6.0",
+				"ms": "2.1.3",
+				"on-finished": "~2.4.1",
+				"range-parser": "~1.2.1",
+				"statuses": "~2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/harper/node_modules/ses": {
+			"version": "1.15.0",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@endo/cache-map": "^1.1.0",
+				"@endo/env-options": "^1.1.11",
+				"@endo/immutable-arraybuffer": "^1.1.2"
+			}
+		},
+		"node_modules/harper/node_modules/set-cookie-parser": {
+			"version": "2.7.2",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/set-function-length": {
+			"version": "1.2.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/harper/node_modules/set-function-name": {
+			"version": "2.0.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"functions-have-names": "^1.2.3",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/harper/node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/harper/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/shell-quote": {
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+			"integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/harper/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/harper/node_modules/slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/sonic-boom": {
+			"version": "3.8.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"node_modules/harper/node_modules/source-map-support/node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/harper/node_modules/splaytree": {
+			"version": "3.2.3",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.20 || >=20"
+			}
+		},
+		"node_modules/harper/node_modules/split2": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 10.x"
+			}
+		},
+		"node_modules/harper/node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/stack-trace": {
+			"version": "0.0.10",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/harper/node_modules/stack-utils": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/harper/node_modules/stack-utils/node_modules/escape-string-regexp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/stackframe": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+			"integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/stacktrace-parser": {
+			"version": "0.1.11",
+			"resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
+			"integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"type-fest": "^0.7.1"
+			},
 			"engines": {
 				"node": ">=6"
 			}
 		},
-		"node_modules/mimic-function": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-			"integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+		"node_modules/harper/node_modules/stacktrace-parser/node_modules/type-fest": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+			"integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/statuses": {
+			"version": "2.0.2",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/harper/node_modules/stdin-discarder": {
+			"version": "0.2.2",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6751,147 +10306,803 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/minimatch": {
-			"version": "10.2.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+		"node_modules/harper/node_modules/stream-browserify": {
+			"version": "3.0.0",
 			"dev": true,
-			"license": "BlueOak-1.0.0",
+			"license": "MIT",
 			"dependencies": {
-				"brace-expansion": "^5.0.5"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"inherits": "~2.0.4",
+				"readable-stream": "^3.5.0"
 			}
 		},
-		"node_modules/minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+		"node_modules/harper/node_modules/stream-browserify/node_modules/readable-stream": {
+			"version": "3.6.2",
 			"dev": true,
 			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/minipass": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": ">= 6"
 			}
 		},
-		"node_modules/mkdirp": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+		"node_modules/harper/node_modules/stream-chain": {
+			"version": "2.2.5",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/harper/node_modules/stream-json": {
+			"version": "1.9.1",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"stream-chain": "^2.2.5"
+			}
+		},
+		"node_modules/harper/node_modules/stream-shift": {
+			"version": "1.0.3",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/streamsearch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/streamx": {
+			"version": "2.23.0",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"events-universal": "^1.0.0",
+				"fast-fifo": "^1.3.2",
+				"text-decoder": "^1.1.0"
+			}
+		},
+		"node_modules/harper/node_modules/string_decoder": {
+			"version": "1.1.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/harper/node_modules/string_decoder/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/string-width": {
+			"version": "4.2.3",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/structon": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/structon/-/structon-1.0.7.tgz",
+			"integrity": "sha512-/6z2LmwKXmVVQhnDo1TUHmnHm5IdZxMh6w60N28y6xAwgGapOOLvANZsCjrp4GVGL26ZXi/jM8s3D14EJpY9pA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"msgpackr": ">=2.0.1"
+			},
+			"peerDependenciesMeta": {
+				"msgpackr": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/harper/node_modules/supports-color": {
+			"version": "7.2.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/systeminformation": {
+			"version": "5.31.9",
+			"resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.9.tgz",
+			"integrity": "sha512-aqepyutSy94zJB552q3LGV2nPfUGZV7LoGhUUjLjs36aLzW3ghpKI7BEpEoQ/OOM+0On4RsyVp1+v6dfYQbqdw==",
+			"dev": true,
+			"license": "MIT",
+			"os": [
+				"darwin",
+				"linux",
+				"win32",
+				"freebsd",
+				"openbsd",
+				"netbsd",
+				"sunos",
+				"android"
+			],
 			"bin": {
-				"mkdirp": "bin/cmd.js"
+				"systeminformation": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"funding": {
+				"type": "Buy me a coffee",
+				"url": "https://www.buymeacoffee.com/systeminfo"
+			}
+		},
+		"node_modules/harper/node_modules/tar-fs": {
+			"version": "3.1.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0",
+				"tar-stream": "^3.1.5"
+			},
+			"optionalDependencies": {
+				"bare-fs": "^4.0.1",
+				"bare-path": "^3.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/tar-stream": {
+			"version": "3.1.8",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"b4a": "^1.6.4",
+				"bare-fs": "^4.5.5",
+				"fast-fifo": "^1.2.0",
+				"streamx": "^2.15.0"
+			}
+		},
+		"node_modules/harper/node_modules/teex": {
+			"version": "1.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"streamx": "^2.12.5"
+			}
+		},
+		"node_modules/harper/node_modules/terser": {
+			"version": "5.48.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+			"integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.15.0",
+				"commander": "^2.20.0",
+				"source-map-support": "~0.5.20"
+			},
+			"bin": {
+				"terser": "bin/terser"
 			},
 			"engines": {
 				"node": ">=10"
 			}
 		},
-		"node_modules/moment": {
-			"version": "2.30.1",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-			"integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+		"node_modules/harper/node_modules/terser/node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/test-exclude": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^7.1.4",
+				"minimatch": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/test-exclude/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/test-exclude/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/harper/node_modules/test-exclude/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/harper/node_modules/test-exclude/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
 			"engines": {
 				"node": "*"
 			}
 		},
-		"node_modules/mqtt-packet": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-9.0.2.tgz",
-			"integrity": "sha512-MvIY0B8/qjq7bKxdN1eD+nrljoeaai+qjLJgfRn3TiMuz0pamsIWY2bFODPZMSNmabsLANXsLl4EMoWvlaTZWA==",
+		"node_modules/harper/node_modules/text-decoder": {
+			"version": "1.2.7",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.6.4"
+			}
+		},
+		"node_modules/harper/node_modules/thread-stream": {
+			"version": "2.7.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"bl": "^6.0.8",
-				"debug": "^4.3.4",
-				"process-nextick-args": "^2.0.1"
+				"real-require": "^0.2.0"
 			}
 		},
-		"node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+		"node_modules/harper/node_modules/throat": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+			"integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/through": {
+			"version": "2.3.8",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/msgpackr": {
-			"version": "1.11.9",
-			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.9.tgz",
-			"integrity": "sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==",
+		"node_modules/harper/node_modules/through2": {
+			"version": "2.0.5",
 			"dev": true,
 			"license": "MIT",
-			"optionalDependencies": {
-				"msgpackr-extract": "^3.0.2"
+			"dependencies": {
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
 			}
 		},
-		"node_modules/msgpackr-extract": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
-			"integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+		"node_modules/harper/node_modules/tiny-emitter": {
+			"version": "2.1.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/tmpl": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/to-regex-range": {
+			"version": "5.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
+		"node_modules/harper/node_modules/toad-cache": {
+			"version": "3.7.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/harper/node_modules/toidentifier": {
+			"version": "1.0.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/harper/node_modules/tr46": {
+			"version": "0.0.3",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/tslib": {
+			"version": "2.8.1",
+			"dev": true,
+			"license": "0BSD"
+		},
+		"node_modules/harper/node_modules/type-detect": {
+			"version": "4.0.8",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/harper/node_modules/type-fest": {
+			"version": "0.21.3",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/harper/node_modules/typed-function": {
+			"version": "4.2.2",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/harper/node_modules/ulidx": {
+			"version": "0.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"layerr": "^0.1.2"
+			}
+		},
+		"node_modules/harper/node_modules/undici-types": {
+			"version": "7.18.2",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/universalify": {
+			"version": "2.0.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/harper/node_modules/update-browserslist-db": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.1"
+			},
+			"bin": {
+				"update-browserslist-db": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
+		"node_modules/harper/node_modules/utf-8-validate": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+			"integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"node-gyp-build-optional-packages": "5.2.2"
+				"node-gyp-build": "^4.3.0"
 			},
-			"bin": {
-				"download-msgpackr-prebuilds": "bin/download-prebuilds.js"
-			},
-			"optionalDependencies": {
-				"@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
-				"@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
-				"@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
-				"@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
-				"@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
-				"@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+			"engines": {
+				"node": ">=6.14.2"
 			}
 		},
-		"node_modules/msgpackr-extract/node_modules/node-gyp-build-optional-packages": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
-			"integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+		"node_modules/harper/node_modules/utf-8-validate/node_modules/node-gyp-build": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"dependencies": {
-				"detect-libc": "^2.0.1"
-			},
 			"bin": {
-				"node-gyp-build-optional-packages": "bin.js",
-				"node-gyp-build-optional-packages-optional": "optional.js",
-				"node-gyp-build-optional-packages-test": "build-test.js"
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
 			}
 		},
-		"node_modules/mute-stream": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/nan": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
-			"integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+		"node_modules/harper/node_modules/utf8": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+			"integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true
+		},
+		"node_modules/harper/node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/utils-merge": {
+			"version": "1.0.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/harper/node_modules/uuid": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
+			}
+		},
+		"node_modules/harper/node_modules/validate.js": {
+			"version": "0.13.1",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/vlq": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
+			"integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/walker": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+			"integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"makeerror": "1.0.12"
+			}
+		},
+		"node_modules/harper/node_modules/wcwidth": {
+			"version": "1.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"defaults": "^1.0.3"
+			}
+		},
+		"node_modules/harper/node_modules/weak-lru-cache": {
+			"version": "1.2.2",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/harper/node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/harper/node_modules/whatwg-fetch": {
+			"version": "3.6.20",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+			"integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/which": {
+			"version": "2.0.2",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/harper/node_modules/winston": {
+			"version": "2.4.7",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"async": "^2.6.4",
+				"colors": "1.0.x",
+				"cycle": "1.0.x",
+				"eyes": "0.1.x",
+				"isstream": "0.1.x",
+				"stack-trace": "0.0.x"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			}
+		},
+		"node_modules/harper/node_modules/winston/node_modules/async": {
+			"version": "2.6.4",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lodash": "^4.17.14"
+			}
+		},
+		"node_modules/harper/node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/harper/node_modules/wrappy": {
+			"version": "1.0.2",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/harper/node_modules/write-file-atomic": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+			"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.7"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/harper/node_modules/write-file-atomic/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/ws": {
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/harper/node_modules/xtend": {
+			"version": "4.0.2",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4"
+			}
+		},
+		"node_modules/harper/node_modules/y18n": {
+			"version": "5.0.8",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/harper/node_modules/yallist": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/harper/node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/harper/node_modules/yargs": {
+			"version": "16.2.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/harper/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/harper/node_modules/yargs/node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
+			}
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.12",
@@ -6909,36 +11120,6 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-			}
-		},
-		"node_modules/needle": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/needle/-/needle-3.5.0.tgz",
-			"integrity": "sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"iconv-lite": "^0.6.3",
-				"sax": "^1.2.4"
-			},
-			"bin": {
-				"needle": "bin/needle"
-			},
-			"engines": {
-				"node": ">= 4.4.x"
-			}
-		},
-		"node_modules/needle/node_modules/iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/next": {
@@ -7477,287 +11658,6 @@
 				}
 			}
 		},
-		"node_modules/node-addon-api": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
-			"integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18 || ^20 || >= 21"
-			}
-		},
-		"node_modules/node-fetch": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"whatwg-url": "^5.0.0"
-			},
-			"engines": {
-				"node": "4.x || >=6.0.0"
-			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/node-forge": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-			"integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-			"dev": true,
-			"license": "(BSD-3-Clause OR GPL-2.0)",
-			"engines": {
-				"node": ">= 6.13.0"
-			}
-		},
-		"node_modules/node-gyp-build": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
-			"integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"node-gyp-build": "bin.js",
-				"node-gyp-build-optional": "optional.js",
-				"node-gyp-build-test": "build-test.js"
-			}
-		},
-		"node_modules/node-gyp-build-optional-packages": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
-			"integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"detect-libc": "^2.0.1"
-			},
-			"bin": {
-				"node-gyp-build-optional-packages": "bin.js",
-				"node-gyp-build-optional-packages-optional": "optional.js",
-				"node-gyp-build-optional-packages-test": "build-test.js"
-			}
-		},
-		"node_modules/node-stream-zip": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
-			"integrity": "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.12.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/antelle"
-			}
-		},
-		"node_modules/node-unix-socket": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/node-unix-socket/-/node-unix-socket-0.2.7.tgz",
-			"integrity": "sha512-Gzdi/wcz0Dd0IPkzl8OfSGmOm3uMMOvOl2yWVyE3E5hdl3tI+0lUVwYc92UnZWt5rWhrkqLBoUivzLVipCoO2w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10"
-			},
-			"optionalDependencies": {
-				"node-unix-socket-darwin-arm64": "0.2.7",
-				"node-unix-socket-darwin-x64": "0.2.7",
-				"node-unix-socket-linux-arm-gnueabihf": "0.2.7",
-				"node-unix-socket-linux-arm64-gnu": "0.2.7",
-				"node-unix-socket-linux-arm64-musl": "0.2.7",
-				"node-unix-socket-linux-x64-gnu": "0.2.7",
-				"node-unix-socket-linux-x64-musl": "0.2.7"
-			}
-		},
-		"node_modules/node-unix-socket-darwin-arm64": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/node-unix-socket-darwin-arm64/-/node-unix-socket-darwin-arm64-0.2.7.tgz",
-			"integrity": "sha512-6wSB386fFnWADWVpAlDq87lZI/0jzLEA7BsRc6QwmMwHonZ/ZbejwEI79iRKnHqFB6wh3TZdHHiKu4csMH1c3w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/node-unix-socket-darwin-x64": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/node-unix-socket-darwin-x64/-/node-unix-socket-darwin-x64-0.2.7.tgz",
-			"integrity": "sha512-eO8pVbchCy7TOvbc8DlIytsSeX6MWPmDVLnSQ8dvAUmsHRGKgJdmO74gr2NwjNmh1h974iW8IpAJfovL+DffHA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/node-unix-socket-linux-arm-gnueabihf": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/node-unix-socket-linux-arm-gnueabihf/-/node-unix-socket-linux-arm-gnueabihf-0.2.7.tgz",
-			"integrity": "sha512-BcC2tGf+Mfs94khO6PWK2a4dJ2wX7HBOuVKxTVqfXZxcrJXplZa0NYn2H9+il4fgIJMb6EbeUo2L3iXpTDJk7w==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/node-unix-socket-linux-arm64-gnu": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/node-unix-socket-linux-arm64-gnu/-/node-unix-socket-linux-arm64-gnu-0.2.7.tgz",
-			"integrity": "sha512-HB4mOFic2u/6KjGHlMJY2q2eAz6btWxzJ0tMYOll+K2WOIuMwT5moZRToc3rjOI6h8bSBMf8ZMwvCz5On9fdoQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/node-unix-socket-linux-arm64-musl": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/node-unix-socket-linux-arm64-musl/-/node-unix-socket-linux-arm64-musl-0.2.7.tgz",
-			"integrity": "sha512-sLuUyCBRWEqBA+EHbhMYgKhEg6zNhiD7nDIJt0zJhWoF7bIrJaRAgBWsdSK/EK8d0a6FYpWIMVVe9CcsApb+lA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/node-unix-socket-linux-x64-gnu": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/node-unix-socket-linux-x64-gnu/-/node-unix-socket-linux-x64-gnu-0.2.7.tgz",
-			"integrity": "sha512-AB3m2YIqUXLSnbezWraa37QNSaViPB/8wYuVsiiXowZzmSBB+o840fgJYV8qcmMlYutwI7Snwy6viPQNNBi8IA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/node-unix-socket-linux-x64-musl": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/node-unix-socket-linux-x64-musl/-/node-unix-socket-linux-x64-musl-0.2.7.tgz",
-			"integrity": "sha512-zVaULR65kXiDh9VLS4fP8bY+jZafByvljMrdyGJc/5zXt//NQK5NqEql/o3c4dPkA+VfIY4GHnjDJWOcxQA+wA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/object-is": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-			"integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"define-properties": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/on-exit-leak-free": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
-			"integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/on-finished": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ee-first": "1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7768,402 +11668,20 @@
 				"wrappy": "1"
 			}
 		},
-		"node_modules/onetime": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mimic-fn": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ora": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
-			"integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^5.3.0",
-				"cli-cursor": "^5.0.0",
-				"cli-spinners": "^2.9.2",
-				"is-interactive": "^2.0.0",
-				"is-unicode-supported": "^2.0.0",
-				"log-symbols": "^6.0.0",
-				"stdin-discarder": "^0.2.2",
-				"string-width": "^7.2.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ora/node_modules/ansi-regex": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/ora/node_modules/chalk": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/ora/node_modules/cli-cursor": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-			"integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"restore-cursor": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ora/node_modules/emoji-regex": {
-			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/ora/node_modules/onetime": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-			"integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mimic-function": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ora/node_modules/restore-cursor": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-			"integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"onetime": "^7.0.0",
-				"signal-exit": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ora/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/ora/node_modules/string-width": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^10.3.0",
-				"get-east-asian-width": "^1.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ora/node_modules/strip-ansi": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^6.2.2"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
-		"node_modules/ordered-binary": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.6.1.tgz",
-			"integrity": "sha512-QkCdPooczexPLiXIrbVOPYkR3VO3T6v2OyKRkR1Xbhpy7/LAVXwahnRCgRp78Oe/Ehf0C/HATAxfSr6eA1oX+w==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/pako": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-			"integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/papaparse": {
-			"version": "5.5.3",
-			"resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
-			"integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/passport": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
-			"integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"passport-strategy": "1.x.x",
-				"pause": "0.0.1",
-				"utils-merge": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/jaredhanson"
-			}
-		},
-		"node_modules/passport-http": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/passport-http/-/passport-http-0.3.0.tgz",
-			"integrity": "sha512-OwK9DkqGVlJfO8oD0Bz1VDIo+ijD3c1ZbGGozIZw+joIP0U60pXY7goB+8wiDWtNqHpkTaQiJ9Ux1jE3Ykmpuw==",
-			"dev": true,
-			"dependencies": {
-				"passport-strategy": "1.x.x"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/passport-local": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
-			"integrity": "sha512-9wCE6qKznvf9mQYYbgJ3sVOHmCWoUNMVFoZzNoznmISbhnNNPhN9xfY3sLmScHMetEJeoY7CXwfhCe7argfQow==",
-			"dev": true,
-			"dependencies": {
-				"passport-strategy": "1.x.x"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/passport-strategy": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
-			"integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/path-expression-matcher": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/path-key": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/path-scurry": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"lru-cache": "^11.0.0",
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/pause": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-			"integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==",
-			"dev": true
-		},
-		"node_modules/peek-stream": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
-			"integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"duplexify": "^3.5.0",
-				"through2": "^2.0.3"
-			}
-		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
 			"license": "ISC"
 		},
-		"node_modules/picomatch": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/pino": {
-			"version": "8.21.0",
-			"resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
-			"integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"atomic-sleep": "^1.0.0",
-				"fast-redact": "^3.1.1",
-				"on-exit-leak-free": "^2.1.0",
-				"pino-abstract-transport": "^1.2.0",
-				"pino-std-serializers": "^6.0.0",
-				"process-warning": "^3.0.0",
-				"quick-format-unescaped": "^4.0.3",
-				"real-require": "^0.2.0",
-				"safe-stable-stringify": "^2.3.1",
-				"sonic-boom": "^3.7.0",
-				"thread-stream": "^2.6.0"
-			},
-			"bin": {
-				"pino": "bin.js"
-			}
-		},
-		"node_modules/pino-abstract-transport": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-			"integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"readable-stream": "^4.0.0",
-				"split2": "^4.0.0"
-			}
-		},
-		"node_modules/pino-std-serializers": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
-			"integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/pino/node_modules/process-warning": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
-			"integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/pkijs": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
-			"integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@noble/hashes": "1.4.0",
-				"asn1js": "^3.0.6",
-				"bytestreamjs": "^2.0.1",
-				"pvtsutils": "^1.3.6",
-				"pvutils": "^1.1.3",
-				"tslib": "^2.8.1"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
 		"node_modules/playwright": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.59.1"
+				"playwright-core": "1.61.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -8176,9 +11694,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -8186,17 +11704,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/polygon-clipping": {
-			"version": "0.15.7",
-			"resolved": "https://registry.npmjs.org/polygon-clipping/-/polygon-clipping-0.15.7.tgz",
-			"integrity": "sha512-nhfdr83ECBg6xtqOAJab1tbksbBAOMUltN60bU+llHVOL0e5Onm1WpAXXWXVB39L8AJFssoIhEVuy/S90MmotA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"robust-predicates": "^3.0.2",
-				"splaytree": "^3.1.0"
 			}
 		},
 		"node_modules/postcss": {
@@ -8227,81 +11734,6 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
-		"node_modules/pprof-format": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.1.tgz",
-			"integrity": "sha512-p4tVN7iK19ccDqQv8heyobzUmbHyds4N2FI6aBMcXz6y99MglTWDxIyhFkNaLeEXs6IFUEzT0zya0icbSLLY0g==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/process": {
-			"version": "0.11.10",
-			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6.0"
-			}
-		},
-		"node_modules/process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/process-warning": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-			"integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/prompt": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/prompt/-/prompt-1.3.0.tgz",
-			"integrity": "sha512-ZkaRWtaLBZl7KKAKndKYUL8WqNT+cQHKRZnT4RYYms48jQkFw3rrBL+/N5K/KtdEveHkxs982MX2BkDKub2ZMg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@colors/colors": "1.5.0",
-				"async": "3.2.3",
-				"read": "1.0.x",
-				"revalidator": "0.1.x",
-				"winston": "2.x"
-			},
-			"engines": {
-				"node": ">= 6.0.0"
-			}
-		},
-		"node_modules/properties-reader": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-2.3.0.tgz",
-			"integrity": "sha512-z597WicA7nDZxK12kZqHr2TcvwNU1GCfA5UwfDY/HDp3hXPoPlb5rlEx9bwGTiJnc0OqbBTkU975jDToth8Gxw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mkdirp": "^1.0.4"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/steveukx/properties?sponsor=1"
-			}
-		},
 		"node_modules/pump": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -8311,121 +11743,6 @@
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
-			}
-		},
-		"node_modules/pumpify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
-			"integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"duplexify": "^4.1.1",
-				"inherits": "^2.0.3",
-				"pump": "^3.0.0"
-			}
-		},
-		"node_modules/pumpify/node_modules/duplexify": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
-			"integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"end-of-stream": "^1.4.1",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.1.1",
-				"stream-shift": "^1.0.2"
-			}
-		},
-		"node_modules/pumpify/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/pvtsutils": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
-			"integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^2.8.1"
-			}
-		},
-		"node_modules/pvutils": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
-			"integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/queue-microtask": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/quick-format-unescaped": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
-			"integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/quickselect": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-			"integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/range-parser": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/rbush": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
-			"integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"quickselect": "^2.0.0"
 			}
 		},
 		"node_modules/react": {
@@ -8455,310 +11772,6 @@
 				"react": "^18.3.1"
 			}
 		},
-		"node_modules/read": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-			"integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"mute-stream": "~0.0.4"
-			},
-			"engines": {
-				"node": ">=0.8"
-			}
-		},
-		"node_modules/readable-stream": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"abort-controller": "^3.0.0",
-				"buffer": "^6.0.3",
-				"events": "^3.3.0",
-				"process": "^0.11.10",
-				"string_decoder": "^1.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/readable-stream/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/readdirp": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14.18.0"
-			},
-			"funding": {
-				"type": "individual",
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/real-require": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
-			"integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12.13.0"
-			}
-		},
-		"node_modules/recursive-iterator": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/recursive-iterator/-/recursive-iterator-3.3.0.tgz",
-			"integrity": "sha512-uc2aWu5ejeqFe4EqOD7eGqY2hn324FS9dEqRl6uOjG002X0SEilk6apBWckqjsL7NDEBjNKaqDOg+ejg30iDTA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/regexp.prototype.flags": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
-			"integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"define-properties": "^1.2.1",
-				"es-errors": "^1.3.0",
-				"get-proto": "^1.0.1",
-				"gopd": "^1.2.0",
-				"set-function-name": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/require-directory": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/require-from-string": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/restore-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/ret": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
-			"integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/reusify": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"iojs": ">=1.0.0",
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/revalidator": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
-			"integrity": "sha512-xcBILK2pA9oh4SiinPEZfhP8HfrB/ha+a2fTMyl7Om2WjlDVrOQy99N2MXXlUHqGJz4qEu2duXxHJjDWuK/0xg==",
-			"dev": true,
-			"license": "Apache 2.0",
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/rfdc": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/robust-predicates": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
-			"integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
-			"dev": true,
-			"license": "Unlicense"
-		},
-		"node_modules/run-async": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.12.0"
-			}
-		},
-		"node_modules/run-parallel": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
-			}
-		},
-		"node_modules/rxjs": {
-			"version": "7.8.2",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-			"integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.1.0"
-			}
-		},
-		"node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/safe-regex2": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
-			"integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"ret": "~0.5.0"
-			},
-			"bin": {
-				"safe-regex2": "bin/safe-regex2.js"
-			}
-		},
-		"node_modules/safe-stable-stringify": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
-			"integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/sax": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=11.0.0"
-			}
-		},
 		"node_modules/scheduler": {
 			"version": "0.23.2",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -8769,142 +11782,18 @@
 				"loose-envify": "^1.1.0"
 			}
 		},
-		"node_modules/secure-json-parse": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
-			"integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/seedrandom": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
-			"integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/segfault-handler": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/segfault-handler/-/segfault-handler-1.3.0.tgz",
-			"integrity": "sha512-p7kVHo+4uoYkr0jmIiTBthwV5L2qmWtben/KDunDZ834mbos+tY+iO0//HpAJpOFSQZZ+wxKWuRo4DxV02B7Lg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "BSD-3-Clause",
-			"optional": true,
-			"dependencies": {
-				"bindings": "^1.2.1",
-				"nan": "^2.14.0"
-			}
-		},
 		"node_modules/semver": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
 			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-			"devOptional": true,
 			"license": "ISC",
+			"optional": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/send": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.4.3",
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"etag": "^1.8.1",
-				"fresh": "^2.0.0",
-				"http-errors": "^2.0.1",
-				"mime-types": "^3.0.2",
-				"ms": "^2.1.3",
-				"on-finished": "^2.4.1",
-				"range-parser": "^1.2.1",
-				"statuses": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/ses": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/ses/-/ses-1.15.0.tgz",
-			"integrity": "sha512-Y7RvgVXhkwQEqVActNn44QBxB2BCUbPfexAaMiUFjbJkDXDnxPisQC5jYQeWOZ3QBOfecnmLfPn0sQKLiYGBAQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@endo/cache-map": "^1.1.0",
-				"@endo/env-options": "^1.1.11",
-				"@endo/immutable-arraybuffer": "^1.1.2"
-			}
-		},
-		"node_modules/set-cookie-parser": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-			"integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/set-function-length": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"define-data-property": "^1.1.4",
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.4",
-				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/set-function-name": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-			"integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"define-data-property": "^1.1.4",
-				"es-errors": "^1.3.0",
-				"functions-have-names": "^1.2.3",
-				"has-property-descriptors": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/setprototypeof": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/sharp": {
 			"version": "0.34.5",
@@ -8951,56 +11840,6 @@
 				"@img/sharp-win32-x64": "0.34.5"
 			}
 		},
-		"node_modules/shebang-command": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"shebang-regex": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/shebang-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/sonic-boom": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
-			"integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"atomic-sleep": "^1.0.0"
-			}
-		},
-		"node_modules/source-map": {
-			"version": "0.7.6",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-			"integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">= 12"
-			}
-		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -9009,109 +11848,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/splaytree": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.2.3.tgz",
-			"integrity": "sha512-7OXrNWzy6CK+r7Ch9OLPBDTKfB6XlWHjX4P0RU5B3IgFuWPeYN0XtRtlexGRjgbQxpfaUve6jTAwBGWuGntz/w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.20 || >=20"
-			}
-		},
-		"node_modules/split2": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">= 10.x"
-			}
-		},
-		"node_modules/stack-trace": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/statuses": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/stdin-discarder": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-			"integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/stream-browserify": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
-			"integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "~2.0.4",
-				"readable-stream": "^3.5.0"
-			}
-		},
-		"node_modules/stream-browserify/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/stream-chain": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
-			"integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/stream-json": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
-			"integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"stream-chain": "^2.2.5"
-			}
-		},
-		"node_modules/stream-shift": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
-			"integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/streamsearch": {
 			"version": "1.1.0",
@@ -9134,57 +11870,6 @@
 				"text-decoder": "^1.1.0"
 			}
 		},
-		"node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "~5.2.0"
-			}
-		},
-		"node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strnum": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/styled-jsx": {
 			"version": "5.1.6",
 			"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -9206,46 +11891,6 @@
 				"babel-plugin-macros": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/systeminformation": {
-			"version": "5.31.5",
-			"resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.5.tgz",
-			"integrity": "sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==",
-			"dev": true,
-			"license": "MIT",
-			"os": [
-				"darwin",
-				"linux",
-				"win32",
-				"freebsd",
-				"openbsd",
-				"netbsd",
-				"sunos",
-				"android"
-			],
-			"bin": {
-				"systeminformation": "lib/cli.js"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			},
-			"funding": {
-				"type": "Buy me a coffee",
-				"url": "https://www.buymeacoffee.com/systeminfo"
 			}
 		},
 		"node_modules/tar-fs": {
@@ -9326,142 +11971,11 @@
 				}
 			}
 		},
-		"node_modules/thread-stream": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
-			"integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"real-require": "^0.2.0"
-			}
-		},
-		"node_modules/through": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/through2": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"readable-stream": "~2.3.6",
-				"xtend": "~4.0.1"
-			}
-		},
-		"node_modules/through2/node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/through2/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/through2/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"node_modules/tiny-emitter": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-number": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8.0"
-			}
-		},
-		"node_modules/toad-cache": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
-			"integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/toidentifier": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
-		"node_modules/tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD"
-		},
-		"node_modules/type-fest": {
-			"version": "0.21.3",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/typed-function": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.2.tgz",
-			"integrity": "sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 18"
-			}
 		},
 		"node_modules/typescript": {
 			"version": "6.0.3",
@@ -9477,192 +11991,12 @@
 				"node": ">=14.17"
 			}
 		},
-		"node_modules/ulidx": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/ulidx/-/ulidx-0.5.0.tgz",
-			"integrity": "sha512-fZFAVMxsp3QSwOpIta6uqc3ZjHfRe4m3GllM+HO4MNQMXlzcUhWihHKWuBxFcDYATsuyxjBwCH0MqVsj/D/how==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"layerr": "^0.1.2"
-			}
-		},
 		"node_modules/undici-types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/utf-8-validate": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-			"integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=6.14.2"
-			}
-		},
-		"node_modules/utf-8-validate/node_modules/node-gyp-build": {
-			"version": "4.8.4",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"bin": {
-				"node-gyp-build": "bin.js",
-				"node-gyp-build-optional": "optional.js",
-				"node-gyp-build-test": "build-test.js"
-			}
-		},
-		"node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/utils-merge": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/uuid": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/esm/bin/uuid"
-			}
-		},
-		"node_modules/validate.js": {
-			"version": "0.13.1",
-			"resolved": "https://registry.npmjs.org/validate.js/-/validate.js-0.13.1.tgz",
-			"integrity": "sha512-PnFM3xiZ+kYmLyTiMgTYmU7ZHkjBZz2/+F0DaALc/uUtVzdCt1wAosvYJ5hFQi/hz8O4zb52FQhHZRC+uVkJ+g==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/wcwidth": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"defaults": "^1.0.3"
-			}
-		},
-		"node_modules/weak-lru-cache": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
-			"integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/webidl-conversions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-			"dev": true,
-			"license": "BSD-2-Clause"
-		},
-		"node_modules/whatwg-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
-			}
-		},
-		"node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/winston": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-2.4.7.tgz",
-			"integrity": "sha512-vLB4BqzCKDnnZH9PHGoS2ycawueX4HLqENXQitvFHczhgW2vFpSOn31LZtVr1KU8YTw7DS4tM+cqyovxo8taVg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"async": "^2.6.4",
-				"colors": "1.0.x",
-				"cycle": "1.0.x",
-				"eyes": "0.1.x",
-				"isstream": "0.1.x",
-				"stack-trace": "0.0.x"
-			},
-			"engines": {
-				"node": ">= 0.10.0"
-			}
-		},
-		"node_modules/winston/node_modules/async": {
-			"version": "2.6.4",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-			"integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"lodash": "^4.17.14"
-			}
-		},
-		"node_modules/wrap-ansi": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
 		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
@@ -9670,93 +12004,6 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/ws": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.4"
-			}
-		},
-		"node_modules/y18n": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/yaml": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
-			}
-		},
-		"node_modules/yargs": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^7.0.2",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.0",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^20.2.2"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
-			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 	},
 	"devDependencies": {
 		"@harperfast/integration-testing": "0.7.0",
-		"@playwright/test": "1.61.1",
+		"@playwright/test": "1.62.0",
 		"@types/node": "^26",
 		"harper": "5.1.23",
 		"next-14": "npm:next@14.2.35",

--- a/package.json
+++ b/package.json
@@ -56,10 +56,10 @@
 		}
 	},
 	"devDependencies": {
-		"@harperfast/integration-testing": "0.3.1",
-		"@playwright/test": "1.59.1",
-		"@types/node": "^20",
-		"harper": "5.0.9",
+		"@harperfast/integration-testing": "0.7.0",
+		"@playwright/test": "1.61.1",
+		"@types/node": "^26",
+		"harper": "5.1.23",
 		"next-14": "npm:next@14.2.35",
 		"next-15": "npm:next@15.5.15",
 		"next-16": "npm:next@16.2.4",

--- a/scripts/install-fixtures.js
+++ b/scripts/install-fixtures.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readdirSync } from 'node:fs';
+import { readdirSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
@@ -13,8 +13,18 @@ const fixtures = readdirSync(fixturesDir, { withFileTypes: true })
 
 for (const fixture of fixtures) {
 	console.log(`Installing ${fixture} dependencies...`);
+	const fixtureDir = join(fixturesDir, fixture);
+
+	// `--install-links` copies `file:../..` instead of symlinking it, so the fixture holds a snapshot
+	// of the plugin rather than a live view. npm considers that snapshot to satisfy the tree and
+	// restores it from its cache on reinstall, so a rebuilt `dist/` never reaches the fixture and
+	// tests silently run stale plugin code. Dropping the copy *and* npm's hidden lockfile forces a
+	// fresh one — without removing `.package-lock.json` npm just re-extracts the cached version.
+	rmSync(join(fixtureDir, 'node_modules', '@harperfast'), { recursive: true, force: true });
+	rmSync(join(fixtureDir, 'node_modules', '.package-lock.json'), { force: true });
+
 	spawnSync('npm', ['install', '--install-links'], {
-		cwd: join(fixturesDir, fixture),
+		cwd: fixtureDir,
 		stdio: 'inherit',
 	});
 	console.log('\n');

--- a/scripts/install-fixtures.js
+++ b/scripts/install-fixtures.js
@@ -13,7 +13,7 @@ const fixtures = readdirSync(fixturesDir, { withFileTypes: true })
 
 for (const fixture of fixtures) {
 	console.log(`Installing ${fixture} dependencies...`);
-	spawnSync('npm', ['install'], {
+	spawnSync('npm', ['install', '--install-links'], {
 		cwd: join(fixturesDir, fixture),
 		stdio: 'inherit',
 	});

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-import type { Scope, Config, FilesOption } from 'harper';
+import { flushDatabases, type Scope, type Config, type FilesOption } from 'harper';
 
 import { createRequire } from 'node:module';
 import { parse as urlParse } from 'node:url';
@@ -278,6 +278,11 @@ async function build(scope: Scope, config: NextPluginConfig, next: NextPackage) 
 
 /** Runs `next build` for the detected Next.js version and returns the resulting BUILD_ID. */
 async function runNextBuild(scope: Scope, config: NextPluginConfig, next: NextPackage): Promise<string> {
+	// Next.js generates static pages using child processes and only a single process can open the
+	// RocksDB databases, so force Harper to start in read-only mode
+	process.env.HARPER_READONLY = 'true';
+	await flushDatabases();
+
 	// --expose-internals is set in Harper's worker execArgv but is not allowed in NODE_OPTIONS.
 	// Next.js reads process.execArgv to forward flags to its own child workers via NODE_OPTIONS,
 	// which causes Node to reject the build worker. Strip it before building and restore after.

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,14 @@
-import { flushDatabases, type Scope, type Config, type FilesOption } from 'harper';
+// Namespace import, not `import { flushDatabases }`. Harper loads components through a sandboxed VM
+// loader where `harper` is a SyntheticModule built from a hardcoded allowlist (getHarperExports in
+// harper's security/jsLoader.ts). `flushDatabases` is a documented package export but is not on that
+// allowlist, so a named import fails at *link* time with "does not provide an export named
+// 'flushDatabases'" — fatal, taking the whole plugin down. A namespace import always links; the
+// property is simply undefined where it isn't exposed, which runNextBuild handles.
+//
+// It *is* defined under `applications.moduleLoader: native`, which bypasses the VM loader and resolves
+// the real package. So this has to work both ways, not just on the default loader.
+import * as harper from 'harper';
+import type { Scope, Config, FilesOption } from 'harper';
 
 import { createRequire } from 'node:module';
 import { parse as urlParse } from 'node:url';
@@ -282,9 +292,29 @@ async function runNextBuild(scope: Scope, config: NextPluginConfig, next: NextPa
 	// RocksDB databases, so force child processes to start Harper in read-only mode. Flush first
 	// so child processes can see all committed data. Unset after the build so the server process
 	// itself is not permanently locked into read-only mode.
+	//
+	// The flush is best-effort in both directions: it isn't reachable on every Harper build (see the
+	// import comment), and it can fail on a transient storage error. Read-only children still open the
+	// databases and replay the on-disk WAL, so a missing flush only risks them not seeing the most
+	// recent writes — worth a warning, not worth failing the build. Nothing here may throw: this runs
+	// before the try/finally below, so an escaping error would leave HARPER_READONLY set on a thread
+	// that goes on serving requests.
 	const prevHarperReadonly = process.env.HARPER_READONLY;
 	process.env.HARPER_READONLY = 'true';
-	await flushDatabases();
+	if (harper.flushDatabases) {
+		try {
+			await harper.flushDatabases();
+		} catch (error) {
+			scope.logger.warn?.('Failed to flush databases before build; static pages may not see the most recent writes: ', error);
+		}
+	} else {
+		scope.logger.warn?.(
+			'harper.flushDatabases is unavailable, so the pre-build flush was skipped and statically generated pages ' +
+				'may not see recently written data. Harper only exposes it to components under the native module ' +
+				'loader; set `applications.moduleLoader: native` in harperdb-config.yaml to enable the flush, at the ' +
+				'cost of per-application tagged logging and config.'
+		);
+	}
 
 	// --expose-internals is set in Harper's worker execArgv but is not allowed in NODE_OPTIONS.
 	// Next.js reads process.execArgv to forward flags to its own child workers via NODE_OPTIONS,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -279,7 +279,10 @@ async function build(scope: Scope, config: NextPluginConfig, next: NextPackage) 
 /** Runs `next build` for the detected Next.js version and returns the resulting BUILD_ID. */
 async function runNextBuild(scope: Scope, config: NextPluginConfig, next: NextPackage): Promise<string> {
 	// Next.js generates static pages using child processes and only a single process can open the
-	// RocksDB databases, so force Harper to start in read-only mode
+	// RocksDB databases, so force child processes to start Harper in read-only mode. Flush first
+	// so child processes can see all committed data. Unset after the build so the server process
+	// itself is not permanently locked into read-only mode.
+	const prevHarperReadonly = process.env.HARPER_READONLY;
 	process.env.HARPER_READONLY = 'true';
 	await flushDatabases();
 
@@ -332,6 +335,11 @@ async function runNextBuild(scope: Scope, config: NextPluginConfig, next: NextPa
 		const buildIdPath = join(scope.directory, '.next', 'BUILD_ID');
 		return readFileSync(buildIdPath, 'utf-8').trim();
 	} finally {
+		if (prevHarperReadonly === undefined) {
+			delete process.env.HARPER_READONLY;
+		} else {
+			process.env.HARPER_READONLY = prevHarperReadonly;
+		}
 		if (exposeInternalsIdx !== -1) process.execArgv.splice(exposeInternalsIdx, 0, '--expose-internals');
 	}
 }


### PR DESCRIPTION
Next.js uses child processes to generate static pages. When those pages reference Harper data, it will try to load those databases and error with:
```
Error: IO error: While lock file: /Users/chris/harper/database/data/LOCK: Resource temporarily unavailable opening database /Users/chris/harper/database/data
    at openRocksDatabase (../harper/resources/databases.ts:162:22)
    at readRocksMetaDb (../harper/resources/databases.ts:407:16)
    at getDatabases (../harper/resources/databases.ts:247:6)
    at database (../harper/resources/databases.ts:734:2)
    at table (../harper/resources/databases.ts:899:20)
    at Object.<anonymous> (../harper/security/auth.ts:27:27)
```

Harper has a new `READONLY` environment variable that will allow a RocksDB database to be opened by another process in read-only mode allowing the static pages to be generated.