### PR TITLE
feat: add turbopack support for Next.js v15

### DIFF
--- a/fixtures/next-15-turbopack/.npmrc
+++ b/fixtures/next-15-turbopack/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/fixtures/next-15-turbopack/app/layout.js
+++ b/fixtures/next-15-turbopack/app/layout.js
@@ -1,0 +1,11 @@
+export const metadata = {
+	title: 'Harper - Next.js v15 App',
+};
+
+export default function RootLayout({ children }) {
+	return (
+		<html>
+			<body>{children}</body>
+		</html>
+	);
+}

--- a/fixtures/next-15-turbopack/app/page.js
+++ b/fixtures/next-15-turbopack/app/page.js
@@ -1,0 +1,7 @@
+export default async function Page() {
+	return (
+		<div>
+			<h1>Next.js v15</h1>
+		</div>
+	);
+}

--- a/fixtures/next-15-turbopack/config.yaml
+++ b/fixtures/next-15-turbopack/config.yaml
@@ -1,3 +1,3 @@
 '@harperfast/nextjs':
   package: '@harperfast/nextjs'
-  bundler: webpack
+  bundler: turbopack

--- a/fixtures/next-15-turbopack/next.config.mjs
+++ b/fixtures/next-15-turbopack/next.config.mjs
@@ -1,0 +1,3 @@
+import { withHarper } from '@harperfast/nextjs';
+
+export default withHarper({});

--- a/fixtures/next-15-turbopack/package.json
+++ b/fixtures/next-15-turbopack/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "next-15",
+	"private": true,
+	"scripts": {
+		"dev": "next dev",
+		"build": "next build",
+		"start": "next start",
+		"lint": "next lint"
+	},
+	"dependencies": {
+		"@harperfast/nextjs": "file:../../",
+		"react": "^19",
+		"react-dom": "^19",
+		"next": "^15"
+	}
+}

--- a/integrationTests/next-15-turbopack.pw.ts
+++ b/integrationTests/next-15-turbopack.pw.ts
@@ -1,0 +1,18 @@
+import { fixture } from './fixture.ts';
+
+const { test, expect } = fixture('next-15-turbopack');
+
+test('home page renders', async ({ page, harper }) => {
+	await page.goto(harper.httpURL);
+	await expect(page.locator('h1')).toHaveText('Next.js v15');
+});
+
+test('page title is set', async ({ page, harper }) => {
+	await page.goto(harper.httpURL);
+	await expect(page).toHaveTitle('Harper - Next.js v15 App');
+});
+
+test('status endpoint returns 200', async ({ request, harper }) => {
+	const response = await request.get(`${harper.operationsAPIURL}/health`);
+	expect(response.status()).toBe(200);
+});

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -14,8 +14,11 @@ import type NextBuildModule15 from 'next-15/dist/cli/next-build.d.ts';
 import type NextModule16 from 'next-16';
 import type NextBuildModule16 from 'next-16/dist/cli/next-build.d.ts';
 
+type Bundler = 'webpack' | 'turbopack';
+
 interface NextPluginConfig extends Config {
 	buildOnly: boolean;
+	bundler: Bundler;
 	dev: boolean;
 	// @ts-expect-error
 	files?: FilesOption;
@@ -23,7 +26,6 @@ interface NextPluginConfig extends Config {
 	prebuilt: boolean;
 	runFirst: boolean;
 	securePort?: number;
-	webpack: boolean;
 }
 
 // Bringing this forward from extension since some validation is better than none.
@@ -64,16 +66,22 @@ function resolveConfig(scope: Scope): NextPluginConfig {
 	}
 
 	assertType('buildOnly', options.buildOnly, 'boolean');
+	assertType('bundler', options.bundler, 'string');
 	assertType('dev', options.dev, 'boolean');
 	assertType('port', options.port, 'number');
 	assertType('prebuilt', options.prebuilt, 'boolean');
 	assertType('runFirst', options.runFirst, 'boolean');
 	assertType('securePort', options.securePort, 'number');
-	assertType('webpack', options.webpack, 'boolean');
+
+	if (options.bundler && options.bundler !== 'webpack' && options.bundler !== 'turbopack') {
+		throw new Error(`bundler must be "webpack" or "turbopack". Received: "${options.bundler}"`);
+	}
 
 	// TODO: Remove type casts when we have more proper plugin option validation from core
 	return {
 		buildOnly: (options.buildOnly as boolean) ?? false,
+		// bundler default is set later in handleApplication() based on the detected Next.js version
+		bundler: options.bundler as Bundler,
 		dev: (options.dev as boolean) ?? false,
 		// @ts-expect-error
 		files: options.files,
@@ -81,7 +89,6 @@ function resolveConfig(scope: Scope): NextPluginConfig {
 		prebuilt: (options.prebuilt as boolean) ?? false,
 		runFirst: (options.runFirst as boolean) ?? false,
 		securePort: options.securePort as number,
-		webpack: (options.webpack as boolean) ?? false,
 	} satisfies NextPluginConfig;
 }
 
@@ -183,6 +190,12 @@ export async function handleApplication(scope: Scope) {
 	// }
 
 	const next = importNext(scope);
+
+	// Set the bundler default based on the detected Next.js version if not explicitly configured.
+	// Next.js v16 defaults to turbopack; v14 and v15 default to webpack.
+	if (!config.bundler) {
+		config.bundler = next.version >= 16 ? 'turbopack' : 'webpack';
+	}
 
 	scope.logger.debug?.(`Detected Next.js version: ${next.version}`);
 
@@ -297,7 +310,7 @@ async function build(scope: Scope, config: NextPluginConfig, next: NextPackage) 
 					{
 						lint: false,
 						mangling: true,
-						turbopack: false,
+						...(config.bundler === 'turbopack' && { turbopack: true }),
 						experimentalDebugMemoryUsage: false,
 						experimentalBuildMode: 'default',
 					},
@@ -308,7 +321,7 @@ async function build(scope: Scope, config: NextPluginConfig, next: NextPackage) 
 				await next.build(
 					{
 						mangling: true,
-						webpack: config.webpack,
+						...(config.bundler === 'webpack' && { webpack: true }),
 						experimentalDebugMemoryUsage: false,
 						experimentalBuildMode: 'default',
 					},
@@ -341,10 +354,10 @@ async function serve(scope: Scope, config: NextPluginConfig, next: NextPackage) 
 			app = next.server({ dir: scope.directory, dev: config.dev });
 			break;
 		case 15:
-			app = next.server({ dir: scope.directory, dev: config.dev, turbopack: false });
+			app = next.server({ dir: scope.directory, dev: config.dev, ...(config.bundler === 'turbopack' && { turbopack: true }) });
 			break;
 		case 16:
-			app = next.server({ dir: scope.directory, dev: config.dev, ...(config.webpack && { webpack: true }) });
+			app = next.server({ dir: scope.directory, dev: config.dev, ...(config.bundler === 'webpack' && { webpack: true }) });
 			break;
 	}
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -197,6 +197,11 @@ export async function handleApplication(scope: Scope) {
 		config.bundler = next.version >= 16 ? 'turbopack' : 'webpack';
 	}
 
+	if (config.bundler === 'turbopack' && next.version === 14) {
+		scope.logger.error?.('Turbopack is not supported for Next.js v14. Falling back to webpack.');
+		config.bundler = 'webpack';
+	}
+
 	scope.logger.debug?.(`Detected Next.js version: ${next.version}`);
 
 	if (config.prebuilt) {


### PR DESCRIPTION
## Summary

- Refactors the `webpack: boolean` plugin option (from #43) into a `bundler` option that accepts `"webpack"` or `"turbopack"` with version-aware defaults:
  - **v16**: defaults to `turbopack` (matches Next.js v16 default)
  - **v15**: defaults to `webpack` (matches Next.js v15 default)
  - **v14**: defaults to `webpack` (no turbopack support)
- Users can now set `bundler: turbopack` for v15 to opt into turbopack, or `bundler: webpack` for v16 to stay on webpack
- Removes the hardcoded `turbopack: false` from v15 build and serve paths
- Adds `next-15-turbopack` fixture and integration test

## Test plan

- [x] `npm run build` — TypeScript compiles clean
- [x] `next-15.pw.ts` — webpack (default): 3/3 passed
- [x] `next-15-turbopack.pw.ts` — turbopack (explicit `bundler: turbopack`): 3/3 passed
- [x] `next-16.pw.ts` — turbopack (default): 3/3 passed
- [x] `next-16-webpack.pw.ts` — webpack (explicit `bundler: webpack`): 3/3 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)