### PR TITLE
feat: add v14 turbopack guard

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -197,6 +197,11 @@ export async function handleApplication(scope: Scope) {
 		config.bundler = next.version >= 16 ? 'turbopack' : 'webpack';
 	}
 
+	if (config.bundler === 'turbopack' && next.version === 14) {
+		scope.logger.error?.('Turbopack is not supported for Next.js v14. Falling back to webpack.');
+		config.bundler = 'webpack';
+	}
+
 	scope.logger.debug?.(`Detected Next.js version: ${next.version}`);
 
 	if (config.prebuilt) {


### PR DESCRIPTION
## Summary

- Next.js v14 does not expose turbopack via its `createServer` or `nextBuild` APIs (turbopack build was gated behind an internal `TURBOPACK_BUILD` env var and threw "next build doesn't support turbopack yet")
- If a user sets `bundler: turbopack` on a v14 application, the plugin now logs an error and falls back to webpack instead of passing unsupported options

## Test plan

- [x] `npm run build` — TypeScript compiles clean
- [x] `next-14.pw.ts` — 3/3 passed (webpack, the only supported bundler)
- [x] `next-15.pw.ts` — 3/3 passed (webpack default)
- [x] `next-15-turbopack.pw.ts` — 3/3 passed (turbopack explicit)
- [x] `next-16.pw.ts` — 3/3 passed (turbopack default)
- [x] `next-16-webpack.pw.ts` — 3/3 passed (webpack explicit)

All 15 tests pass across all 5 configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)