### PR TITLE
ci: force nextjs checkout in reusable integration-tests workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,8 +42,16 @@ jobs:
       node-versions: ${{ steps.set-node-versions.outputs.node-versions }}
 
     steps:
+      # Always check out THIS repo's code, even when invoked as a reusable
+      # workflow. In a `workflow_call`, `github.repository` is the caller (e.g.
+      # HarperFast/harper), so a default checkout would pull the caller's source.
+      # `github.job_workflow_sha` is the pinned SHA of this reusable workflow
+      # file; it is empty on direct runs, where we fall back to `github.sha`.
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: HarperFast/nextjs
+          ref: ${{ github.job_workflow_sha || github.sha }}
 
       - name: Set Node versions
         id: set-node-versions
@@ -66,8 +74,14 @@ jobs:
         node-version: ${{ fromJSON(needs.generate-node-version-matrix.outputs.node-versions) }}
 
     steps:
+      # See note in generate-node-version-matrix: force this repo's code so a
+      # reusable-workflow caller's checkout context doesn't run the caller's
+      # package.json scripts (build/install:fixtures/test:integration).
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: HarperFast/nextjs
+          ref: ${{ github.job_workflow_sha || github.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Problem

`integration-tests.yml` is now consumed as a **reusable workflow** (`workflow_call`, added in #49) by `HarperFast/harper`'s downstream gate ([harper#1385](https://github.com/HarperFast/harper/pull/1385)). When it runs in that context every matrix job fails fast at the `Install fixture dependencies` step:

```
npm error Missing script: "install:fixtures"
```

## Root cause

In a `workflow_call`, `github.repository` resolves to the **caller** (`HarperFast/harper`), not this repo. The primary `Checkout code` step uses `actions/checkout` with default inputs, so it checks out **harper's** source into `$GITHUB_WORKSPACE`. The subsequent `npm run build` / `install:fixtures` / `test:integration` steps then run against harper's `package.json`:

- harper *has* a `build` script → `npm run build` passes
- harper has **no** `install:fixtures` / `test:integration` → fails

The `harper-override` checkout added in #49 correctly pinned `repository: HarperFast/harper`, but the primary checkout was left defaulting — fine for this repo's own push/PR runs, broken for reusable-workflow callers.

## Fix

Pin the primary checkouts to `HarperFast/nextjs` at the reusable workflow's own pinned SHA via `github.job_workflow_sha`, falling back to `github.sha` for direct push/pull_request runs (where `job_workflow_sha` is empty). Both repos are public, so the default `GITHUB_TOKEN` suffices for the cross-repo checkout — no PAT needed.

## Coordination note

harper#1385 currently pins this workflow at `d4b5ac9` (pre-fix). After this merges, harper#1385's `uses: HarperFast/nextjs/...@<sha>` pin must be bumped to the merge commit for the fix to take effect — `github.job_workflow_sha` will then resolve to the fixed commit.

## Notes

- Not assigning reviewers — this is framework-hosting/CI (Ethan's area); routing left to the team.
- Diagnosed while investigating the CI failure blocking harper#1385 from becoming a required gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)