### PR TITLE
fix: schedule the build-claim heartbeat with recursive setTimeout

### DIFF
--- a/src/buildLock.test.ts
+++ b/src/buildLock.test.ts
@@ -169,8 +169,8 @@ describe('withBuildLock', () => {
 	});
 
 	it('re-stamps the claim on a heartbeat while a long build runs, then records success', async (t) => {
-		// Mock only setInterval — the heartbeat's timer. This path never reaches the waiter's sleep().
-		t.mock.timers.enable({ apis: ['setInterval'] });
+		// Mock only setTimeout — the heartbeat's timer. This path never reaches the waiter's sleep().
+		t.mock.timers.enable({ apis: ['setTimeout'] });
 		const events: string[] = [];
 		const table = makeTable(events); // get → undefined (no existing record)
 		useTable(t, table);

--- a/src/buildLock.ts
+++ b/src/buildLock.ts
@@ -56,26 +56,27 @@ function startClaimHeartbeat(table: BuildInfoTable, key: string, scope: Scope): 
 	let timer: ReturnType<typeof setTimeout>;
 	let inFlight: Promise<unknown> = Promise.resolve();
 
+	function scheduleNext() {
+		timer = setTimeout(beat, HEARTBEAT_MS);
+		// Don't let the heartbeat timer keep the process alive on its own.
+		timer.unref?.();
+	}
+
 	// Recursive setTimeout (not setInterval) so the next beat is scheduled only after the current write
 	// settles — at most one re-stamp is ever in flight, so a slow write can't land after the terminal
 	// record and revert the claim. Chaining off Promise.resolve() also turns a synchronous throw from
 	// table.put into a caught rejection rather than an uncaught error in the timer callback.
-	const beat = () => {
+	function beat() {
 		if (stopped) return;
 		inFlight = Promise.resolve()
 			.then(() => table.put(key, { buildId: null, status: 'building' }))
 			.catch((error) => scope.logger.debug?.(`Heartbeat for ${key} build claim failed`, error))
 			.finally(() => {
-				if (!stopped) {
-					timer = setTimeout(beat, HEARTBEAT_MS);
-					timer.unref?.();
-				}
+				if (!stopped) scheduleNext();
 			});
-	};
+	}
 
-	timer = setTimeout(beat, HEARTBEAT_MS);
-	// Don't let the heartbeat timer keep the process alive on its own.
-	timer.unref?.();
+	scheduleNext();
 
 	return async () => {
 		stopped = true;

--- a/src/buildLock.ts
+++ b/src/buildLock.ts
@@ -53,18 +53,33 @@ function buildInfoTable(): BuildInfoTable | undefined {
  */
 function startClaimHeartbeat(table: BuildInfoTable, key: string, scope: Scope): () => Promise<void> {
 	let stopped = false;
+	let timer: ReturnType<typeof setTimeout>;
 	let inFlight: Promise<unknown> = Promise.resolve();
-	const timer = setInterval(() => {
+
+	// Recursive setTimeout (not setInterval) so the next beat is scheduled only after the current write
+	// settles — at most one re-stamp is ever in flight, so a slow write can't land after the terminal
+	// record and revert the claim. Chaining off Promise.resolve() also turns a synchronous throw from
+	// table.put into a caught rejection rather than an uncaught error in the timer callback.
+	const beat = () => {
 		if (stopped) return;
-		inFlight = Promise.resolve(table.put(key, { buildId: null, status: 'building' })).catch((error) => {
-			scope.logger.debug?.(`Heartbeat for ${key} build claim failed`, error);
-		});
-	}, HEARTBEAT_MS);
+		inFlight = Promise.resolve()
+			.then(() => table.put(key, { buildId: null, status: 'building' }))
+			.catch((error) => scope.logger.debug?.(`Heartbeat for ${key} build claim failed`, error))
+			.finally(() => {
+				if (!stopped) {
+					timer = setTimeout(beat, HEARTBEAT_MS);
+					timer.unref?.();
+				}
+			});
+	};
+
+	timer = setTimeout(beat, HEARTBEAT_MS);
 	// Don't let the heartbeat timer keep the process alive on its own.
 	timer.unref?.();
+
 	return async () => {
 		stopped = true;
-		clearInterval(timer);
+		clearTimeout(timer);
 		await inFlight;
 	};
 }


### PR DESCRIPTION
Follow-up to #53. The build-claim heartbeat it introduced used `setInterval`; a code-review pass on the sibling vite change ([HarperFast/vite#26](https://github.com/HarperFast/vite/pull/26)) flagged two issues with that approach, and the same code is now on `main` here.

## Problems with the `setInterval` heartbeat

1. **Overlapping writes.** `setInterval` fires every `HEARTBEAT_MS` regardless of whether the previous `table.put` resolved. If a write ever takes longer than the interval (DB load, contention), two re-stamps are in flight; a slow earlier `building` write can land *after* the terminal `success`/`failure` write and revert the record to `building` — leaving the claim stuck until it goes stale (up to `STALE_CLAIM_MS`). Low probability with sub-ms LMDB writes, but a real correctness hole.
2. **Synchronous throw.** `Promise.resolve(table.put(...))` doesn't catch a *synchronous* throw from `table.put` — it would escape the `.catch` and surface as an uncaught error in the timer callback.

## Fix

Recursive `setTimeout` instead of `setInterval`:

- The next beat is scheduled only after the current write **settles** (in `.finally`), so **at most one re-stamp is ever in flight** — a slow write can't outlive the terminal record.
- `stopHeartbeat()` awaits that single in-flight write before the terminal `success`/`failure` write, preserving "terminal record is the last word."
- Chaining off `Promise.resolve().then(() => table.put(...))` converts a synchronous `table.put` throw into a **caught rejection**.

## Testing

`npm test` — **10/10 pass** (heartbeat test now mocks `setTimeout`); `tsc --noEmit` clean.

Mirrors the identical fix in [HarperFast/vite#26](https://github.com/HarperFast/vite/pull/26), keeping the two plugins' build locks in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)