### PR TITLE
fix: install conventionalcommits preset for semantic-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,7 @@ jobs:
           extra_plugins: |
             @semantic-release/commit-analyzer
             @semantic-release/release-notes-generator
+            conventional-changelog-conventionalcommits
             @semantic-release/npm
             @semantic-release/git
             @semantic-release/github


### PR DESCRIPTION
## The failure

The first Release run after #54 merged [failed](https://github.com/HarperFast/nextjs/actions/runs/30030848769/job/89286750772) at the **Semantic Release** step (Build passed):

```
[semantic-release] › ✘  An error occurred while running semantic-release:
Error: Cannot find module 'conventional-changelog-conventionalcommits'
```

## Cause

`.releaserc.json` configures `@semantic-release/release-notes-generator` with `preset: "conventionalcommits"`. That preset lives in the separate `conventional-changelog-conventionalcommits` package — release-notes-generator only ships `conventional-changelog-angular` as a dependency (confirmed: `npm view @semantic-release/release-notes-generator@14 dependencies`). `cycjimmy/semantic-release-action` installs only the packages listed in `extra_plugins`, and that list didn't include the preset, so the module wasn't present at release time.

## Fix

Add `conventional-changelog-conventionalcommits` to `extra_plugins`. Unpinned, matching the workflow's existing "track latest" posture — the action installs the latest semantic-release, and the latest preset (`10.2.1`, which only pulls `@conventional-changelog/template`) is the matching pairing. This got through review originally because it's inherited verbatim from vite's workflow, which has the same latent gap.

## Notes
- This is workflow-only; it re-runs on the next push to `main` (or via **Run workflow**). Nothing to build/test locally.
- Auth/provenance was never reached — the failure was during changelog-preset loading, before publish — so this unblocks the step you set provenance up for.
- Same fix for vite is in HarperFast/vite (its `release.yaml` has the identical gap).
- If you'd prefer reproducible releases over "latest", we could pin `conventional-changelog-conventionalcommits` (and semantic-release) to explicit versions here and in vite — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)