### PR TITLE
fix(release): pin conventionalcommits preset to v9 and align release-note sections

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
           extra_plugins: |
             @semantic-release/commit-analyzer
             @semantic-release/release-notes-generator
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@^9.3.1
             @semantic-release/npm
             @semantic-release/git
             @semantic-release/github

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,13 +9,17 @@
 				"presetConfig": {
 					"types": [
 						{ "type": "feat", "section": "Features" },
-						{ "type": "docs", "section": "Documentation" },
 						{ "type": "fix", "section": "Bug Fixes" },
 						{ "type": "perf", "section": "Performance Improvements" },
-						{ "type": "refactor", "section": "Code Improvements" },
-						{ "type": "revert", "section": "Reverts" },
-						{ "type": "test", "section": "Test Improvements" },
-						{ "type": "chore", "scope": "deps", "section": "Dependency Updates" }
+						{ "type": "refactor", "section": "Refactoring" },
+						{ "type": "chore", "scope": "deps", "section": "Dependency Updates", "hidden": false },
+						{ "type": "chore", "section": "Chores", "hidden": false },
+						{ "type": "docs", "section": "Documentation" },
+						{ "type": "style", "section": "Styles" },
+						{ "type": "test", "section": "Tests" },
+						{ "type": "build", "section": "Build System" },
+						{ "type": "ci", "section": "Continuous Integration" },
+						{ "type": "revert", "section": "Reverts" }
 					]
 				}
 			}


### PR DESCRIPTION
## Why

Our semantic-release repos generate GitHub release notes with the `conventionalcommits` preset, but the behavior had drifted and, in several repos, notes were coming out **empty**. Two separate causes:

1. **Preset v10 breaks rendering.** `@semantic-release/release-notes-generator@14` still bundles the Handlebars-based `conventional-changelog-writer@8`. The `conventional-changelog-conventionalcommits` **v10** preset rewrote its templates as JS functions for the newer `@conventional-changelog/template` engine (writer@9); fed to writer@8 only the header survives, so every release note collapses to just its `## [x.y.z]…` line.
2. **`presetConfig.types` drift.** Types like `chore`/`chore(deps)`/`ci`/`build`/`style` were hidden or missing, so dependency-only releases (the common Renovate case) produced empty notes.

This PR makes the repo consistent with **studio**'s canonical release config (which surfaces every commit type) and holds the preset on v9 where relevant. Reference: HarperFast/studio#1560.

## What changed

- Pinned `conventional-changelog-conventionalcommits@^9.3.1` in the release workflow's `extra_plugins` (it was unpinned → pulled v10 → empty notes; e.g. v2.2.3 dropped a `fix:` commit).
- Aligned `.releaserc.json` `presetConfig.types` to studio's superset.

## Canonical `presetConfig.types` (matches studio)

`feat`→Features, `fix`→Bug Fixes, `perf`→Performance Improvements, `refactor`→Refactoring, `chore(deps)`→Dependency Updates, `chore`→Chores, `docs`→Documentation, `style`→Styles, `test`→Tests, `build`→Build System, `ci`→Continuous Integration, `revert`→Reverts — nothing hidden, so no release comes out empty.

## Verification

- `.releaserc.json` is valid JSON; the pinned `extra_plugins` line resolves to a 9.x preset.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
